### PR TITLE
Support BFP_ENVIRONMENT variable in Python example

### DIFF
--- a/python/example/main.py
+++ b/python/example/main.py
@@ -22,6 +22,12 @@ import openapi_client as api
 
 log = logging.getLogger("main")
 
+ENVIRONMENT = (
+    getattr(Environment, env.upper())
+    if (env := os.environ.get("BFP_ENVIRONMENT"))
+    else Environment.STAGING
+)
+
 LOG_LEVEL = (
     getattr(logging, level.upper())
     if (level := os.environ.get("BFP_LOG_LEVEL"))
@@ -72,7 +78,8 @@ async def main():
     # unrelated to the fact that we're trading on the SUI-PERP market.
     log.info(f"{sui_wallet.sui_address=}")
 
-    async with BluefinProSdk(sui_wallet, Environment.STAGING, debug=True) as client:
+    log.info(f"Connecting to {ENVIRONMENT}")
+    async with BluefinProSdk(sui_wallet, ENVIRONMENT, debug=True) as client:
         # Get Market Data from the Exchange Data API.
         exchange_data_api = client.exchange_data_api
         exchange_info = await client.exchange_data_api.get_exchange_info()

--- a/python/sdk/src/bluefin_pro_sdk.py
+++ b/python/sdk/src/bluefin_pro_sdk.py
@@ -49,8 +49,6 @@ class Order:
     self_trade_prevention_type: SelfTradePreventionType = None
 
 
-env_name = environ.get("ENV", "sui-prod")
-
 logger = logging.getLogger(__name__)
 
 

--- a/rust/src/bin/apigen.rs
+++ b/rust/src/bin/apigen.rs
@@ -1,9 +1,9 @@
 //! This is how Bluefin generates Rust code from the accompanying OpenAPI specifications.
 //!
-//! To install this command locally, cd to parent `rust` directory and run:
+//! To install this command locally, change to the parent `rust` directory and run:
 //!
 //! ```sh
-//! cargo install --path .
+//! cargo install --path . --bin apigen
 //! ```
 //!
 //! If you don't have `cargo`, start [here](https://rustup.rs/).
@@ -74,9 +74,9 @@ impl Lang {
     /// Returns a repo-relative path to the OpenAPI definition for this language.
     fn config(self) -> &'static str {
         match self {
-            Lang::Python => "python/gen/config.yaml",
+            Lang::Python => "python/sdk/config.yaml",
             Lang::Rust => "rust/gen/config.yaml",
-            Lang::Typescript => "typescript-axios/gen/config.yaml",
+            Lang::Typescript => "ts/sdk/openapitools.json",
         }
     }
 
@@ -86,6 +86,15 @@ impl Lang {
             Lang::Python => "python",
             Lang::Rust => "rust",
             Lang::Typescript => "typescript-axios",
+        }
+    }
+
+    /// Returns the target directory path where code should be generated.
+    fn output(self) -> &'static str {
+        match self {
+            Lang::Python => "python/sdk/src",
+            Lang::Rust => "rust/gen/bluefin_api",
+            Lang::Typescript => "ts/sdk/src",
         }
     }
 }
@@ -114,13 +123,12 @@ impl FromStr for Lang {
 /// Will return `Err` if the OpenAPI generator cannot be found, or if it returns bad status.
 fn generate(lang: Lang) -> Result<()> {
     let command = "openapi-generator";
-    let generator = lang.generator();
     Command::new(command)
         .arg("generate")
         .args(["--input-spec", &format!("{INPUT_DIR}/bluefin-api.yaml")])
         .args(["--config", lang.config()])
-        .args(["--generator-name", generator])
-        .args(["--output", &format!("{generator}/gen/bluefin_api")])
+        .args(["--generator-name", lang.generator()])
+        .args(["--output", lang.output()])
         .status()?
         .success()
         .then_some(())


### PR DESCRIPTION
This commit also updates a Rust script that is convenient for calling the OpenAPI generator.