### PR TITLE
Make 'contracts' optional

### DIFF
--- a/python/.env
+++ b/python/.env
@@ -1,3 +1,3 @@
 # This environment variables can be used to configure IDEs such as VS Code.
 # The path should be relative to the folder opened in the IDE.
-PYTHONPATH=python/sdk/src
+PYTHONPATH=sdk/src

--- a/python/example/main.py
+++ b/python/example/main.py
@@ -88,7 +88,9 @@ async def main():
     log.info(f"{sui_wallet.sui_address=}")
 
     log.info(f"Connecting to {ENVIRONMENT}")
-    async with BluefinProSdk(sui_wallet, contracts=None,rpc_url=RPC_URL, env=ENVIRONMENT, debug=True) as client:
+    async with BluefinProSdk(
+        sui_wallet, contracts=None, rpc_url=RPC_URL, env=ENVIRONMENT, debug=True
+    ) as client:
         # Get Market Data from the Exchange Data API.
         exchange_data_api = client.exchange_data_api
         exchange_info = await client.exchange_data_api.get_exchange_info()

--- a/python/sdk/src/bluefin_pro_sdk.py
+++ b/python/sdk/src/bluefin_pro_sdk.py
@@ -76,7 +76,7 @@ class BluefinProSdk:
 
     def __init__(self, 
                  sui_wallet: SuiWallet, 
-                 contracts: ProContracts, 
+                 contracts: ProContracts | None,
                  rpc_url: str,
                  env: Environment = Environment.PRODUCTION, 
                  authorized_address: str = None,


### PR DESCRIPTION
There's a ton of similar type errors within the Python SDK.  Somebody declared types, but never ran the type checker.