### PR TITLE
fix: symbol in getOpenOrders should be optional

### DIFF
--- a/ts/sdk/src/sdk.ts
+++ b/ts/sdk/src/sdk.ts
@@ -246,7 +246,7 @@ export class BluefinProSdk {
     return this.tokenResponse!.accessToken;
   }
 
-  public async getOpenOrders(symbol: string) {
+  public async getOpenOrders(symbol?: string) {
     await this.setAccessToken();
     return await this.tradeApi.getOpenOrders(symbol);
   }


### PR DESCRIPTION
- The `symbol` param in `getOpenOrders` should match the `tradeApi.getOpenOrders` signature. This will allow the front-end to fetch _all_ open orders.