### PR TITLE
[BFP-1022] Add Enum.UNSPECIFIED to ADS endpoints

### DIFF
--- a/python/sdk/src/openapi_client/api/account_data_api.py
+++ b/python/sdk/src/openapi_client/api/account_data_api.py
@@ -561,7 +561,7 @@ class AccountDataApi:
         start_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Start time in milliseconds. Defaults to 7 days ago if not specified.")] = None,
         end_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]], Field(description="Default 500; max 1000.")] = None,
-        trade_type: Annotated[Optional[TradeTypeEnum], Field(description="Type of trade. By default returns all.")] = None,
+        trade_type: Annotated[Optional[TradeTypeEnum], Field(description="Type of trade. By default returns all. UNSPECIFIED returns all.")] = None,
         page: Annotated[Optional[Annotated[int, Field(strict=True, ge=1)]], Field(description="The page number to retrieve in a paginated response.")] = None,
         _request_timeout: Union[
             None,
@@ -587,7 +587,7 @@ class AccountDataApi:
         :type end_time_at_millis: int
         :param limit: Default 500; max 1000.
         :type limit: int
-        :param trade_type: Type of trade. By default returns all.
+        :param trade_type: Type of trade. By default returns all. UNSPECIFIED returns all.
         :type trade_type: TradeTypeEnum
         :param page: The page number to retrieve in a paginated response.
         :type page: int
@@ -651,7 +651,7 @@ class AccountDataApi:
         start_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Start time in milliseconds. Defaults to 7 days ago if not specified.")] = None,
         end_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]], Field(description="Default 500; max 1000.")] = None,
-        trade_type: Annotated[Optional[TradeTypeEnum], Field(description="Type of trade. By default returns all.")] = None,
+        trade_type: Annotated[Optional[TradeTypeEnum], Field(description="Type of trade. By default returns all. UNSPECIFIED returns all.")] = None,
         page: Annotated[Optional[Annotated[int, Field(strict=True, ge=1)]], Field(description="The page number to retrieve in a paginated response.")] = None,
         _request_timeout: Union[
             None,
@@ -677,7 +677,7 @@ class AccountDataApi:
         :type end_time_at_millis: int
         :param limit: Default 500; max 1000.
         :type limit: int
-        :param trade_type: Type of trade. By default returns all.
+        :param trade_type: Type of trade. By default returns all. UNSPECIFIED returns all.
         :type trade_type: TradeTypeEnum
         :param page: The page number to retrieve in a paginated response.
         :type page: int
@@ -741,7 +741,7 @@ class AccountDataApi:
         start_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Start time in milliseconds. Defaults to 7 days ago if not specified.")] = None,
         end_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]], Field(description="Default 500; max 1000.")] = None,
-        trade_type: Annotated[Optional[TradeTypeEnum], Field(description="Type of trade. By default returns all.")] = None,
+        trade_type: Annotated[Optional[TradeTypeEnum], Field(description="Type of trade. By default returns all. UNSPECIFIED returns all.")] = None,
         page: Annotated[Optional[Annotated[int, Field(strict=True, ge=1)]], Field(description="The page number to retrieve in a paginated response.")] = None,
         _request_timeout: Union[
             None,
@@ -767,7 +767,7 @@ class AccountDataApi:
         :type end_time_at_millis: int
         :param limit: Default 500; max 1000.
         :type limit: int
-        :param trade_type: Type of trade. By default returns all.
+        :param trade_type: Type of trade. By default returns all. UNSPECIFIED returns all.
         :type trade_type: TradeTypeEnum
         :param page: The page number to retrieve in a paginated response.
         :type page: int

--- a/python/sdk/src/openapi_client/docs/AccountDataApi.md
+++ b/python/sdk/src/openapi_client/docs/AccountDataApi.md
@@ -202,7 +202,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     start_time_at_millis = 56 # int | Start time in milliseconds. Defaults to 7 days ago if not specified. (optional)
     end_time_at_millis = 56 # int | End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart. (optional)
     limit = 500 # int | Default 500; max 1000. (optional) (default to 500)
-    trade_type = openapi_client.TradeTypeEnum() # TradeTypeEnum | Type of trade. By default returns all. (optional)
+    trade_type = openapi_client.TradeTypeEnum() # TradeTypeEnum | Type of trade. By default returns all. UNSPECIFIED returns all. (optional)
     page = 56 # int | The page number to retrieve in a paginated response. (optional)
 
     try:
@@ -225,7 +225,7 @@ Name | Type | Description  | Notes
  **start_time_at_millis** | **int**| Start time in milliseconds. Defaults to 7 days ago if not specified. | [optional] 
  **end_time_at_millis** | **int**| End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart. | [optional] 
  **limit** | **int**| Default 500; max 1000. | [optional] [default to 500]
- **trade_type** | [**TradeTypeEnum**](.md)| Type of trade. By default returns all. | [optional] 
+ **trade_type** | [**TradeTypeEnum**](.md)| Type of trade. By default returns all. UNSPECIFIED returns all. | [optional] 
  **page** | **int**| The page number to retrieve in a paginated response. | [optional] 
 
 ### Return type

--- a/python/sdk/src/openapi_client/docs/MarginTypeEnum.md
+++ b/python/sdk/src/openapi_client/docs/MarginTypeEnum.md
@@ -8,6 +8,8 @@ Margin type.
 
 * `ISOLATED` (value: `'ISOLATED'`)
 
+* `UNSPECIFIED` (value: `'UNSPECIFIED'`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/python/sdk/src/openapi_client/docs/PositionSideEnum.md
+++ b/python/sdk/src/openapi_client/docs/PositionSideEnum.md
@@ -8,6 +8,8 @@ The side of the position, either long or short
 
 * `SHORT` (value: `'SHORT'`)
 
+* `UNSPECIFIED` (value: `'UNSPECIFIED'`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/python/sdk/src/openapi_client/docs/TradeSideEnum.md
+++ b/python/sdk/src/openapi_client/docs/TradeSideEnum.md
@@ -8,6 +8,8 @@ Trade side based on the user order in this trade.
 
 * `SHORT` (value: `'SHORT'`)
 
+* `UNSPECIFIED` (value: `'UNSPECIFIED'`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/python/sdk/src/openapi_client/docs/TradeTypeEnum.md
+++ b/python/sdk/src/openapi_client/docs/TradeTypeEnum.md
@@ -10,6 +10,8 @@ Type of trade.
 
 * `DELEVERAGE` (value: `'DELEVERAGE'`)
 
+* `UNSPECIFIED` (value: `'UNSPECIFIED'`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/python/sdk/src/openapi_client/docs/TransactionTypeEnum.md
+++ b/python/sdk/src/openapi_client/docs/TransactionTypeEnum.md
@@ -20,6 +20,8 @@ Transaction type (what caused the change in the asset balance).
 
 * `BONUS` (value: `'BONUS'`)
 
+* `UNSPECIFIED` (value: `'UNSPECIFIED'`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/python/sdk/src/openapi_client/models/margin_type_enum.py
+++ b/python/sdk/src/openapi_client/models/margin_type_enum.py
@@ -28,6 +28,7 @@ class MarginTypeEnum(str, Enum):
     """
     CROSS = 'CROSS'
     ISOLATED = 'ISOLATED'
+    UNSPECIFIED = 'UNSPECIFIED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python/sdk/src/openapi_client/models/position_side_enum.py
+++ b/python/sdk/src/openapi_client/models/position_side_enum.py
@@ -28,6 +28,7 @@ class PositionSideEnum(str, Enum):
     """
     LONG = 'LONG'
     SHORT = 'SHORT'
+    UNSPECIFIED = 'UNSPECIFIED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python/sdk/src/openapi_client/models/trade.py
+++ b/python/sdk/src/openapi_client/models/trade.py
@@ -51,8 +51,8 @@ class Trade(BaseModel):
     @field_validator('trading_fee_asset')
     def trading_fee_asset_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['USDC', 'BLUE']):
-            raise ValueError("must be one of enum values ('USDC', 'BLUE')")
+        if value not in set(['USDC', 'BLUE', 'UNSPECIFIED']):
+            raise ValueError("must be one of enum values ('USDC', 'BLUE', 'UNSPECIFIED')")
         return value
 
     model_config = ConfigDict(

--- a/python/sdk/src/openapi_client/models/trade_side_enum.py
+++ b/python/sdk/src/openapi_client/models/trade_side_enum.py
@@ -28,6 +28,7 @@ class TradeSideEnum(str, Enum):
     """
     LONG = 'LONG'
     SHORT = 'SHORT'
+    UNSPECIFIED = 'UNSPECIFIED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python/sdk/src/openapi_client/models/trade_type_enum.py
+++ b/python/sdk/src/openapi_client/models/trade_type_enum.py
@@ -29,6 +29,7 @@ class TradeTypeEnum(str, Enum):
     ORDER = 'ORDER'
     LIQUIDATION = 'LIQUIDATION'
     DELEVERAGE = 'DELEVERAGE'
+    UNSPECIFIED = 'UNSPECIFIED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python/sdk/src/openapi_client/models/transaction_type_enum.py
+++ b/python/sdk/src/openapi_client/models/transaction_type_enum.py
@@ -34,6 +34,7 @@ class TransactionTypeEnum(str, Enum):
     TRADING_FEE = 'TRADING_FEE'
     TRADING_GAS_FEE = 'TRADING_GAS_FEE'
     BONUS = 'BONUS'
+    UNSPECIFIED = 'UNSPECIFIED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/resources/account-data-api.yaml
+++ b/resources/account-data-api.yaml
@@ -220,6 +220,7 @@ components:
           enum:
             - USDC
             - BLUE
+            - UNSPECIFIED
           description: Asset used for trading fee.
           example: USDC
         gasFeeE9:
@@ -378,18 +379,21 @@ components:
         - ORDER
         - LIQUIDATION
         - DELEVERAGE
+        - UNSPECIFIED
     PositionSideEnum:
       type: string
       description: "The side of the position, either long or short"
       enum:
         - LONG
         - SHORT
+        - UNSPECIFIED
     TradeSideEnum:
       type: string
       description: Trade side based on the user order in this trade.
       enum:
         - LONG
         - SHORT
+        - UNSPECIFIED
     TransactionTypeEnum:
       description: Transaction type (what caused the change in the asset balance).
       type: string
@@ -402,12 +406,14 @@ components:
         - TRADING_FEE
         - TRADING_GAS_FEE
         - BONUS
+        - UNSPECIFIED
     MarginTypeEnum:
       type: string
       description: Margin type.
       enum:
         - CROSS
         - ISOLATED
+        - UNSPECIFIED
     Error:
       required:
         - message
@@ -549,7 +555,7 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/TradeTypeEnum"
-          description: Type of trade. By default returns all.
+          description: Type of trade. By default returns all. UNSPECIFIED returns all.
         - name: page
           in: query
           required: false

--- a/rust/gen/bluefin_api/docs/AccountDataApi.md
+++ b/rust/gen/bluefin_api/docs/AccountDataApi.md
@@ -75,7 +75,7 @@ Name | Type | Description  | Required | Notes
 **start_time_at_millis** | Option<**u32**> | Start time in milliseconds. Defaults to 7 days ago if not specified. |  |
 **end_time_at_millis** | Option<**u32**> | End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart. |  |
 **limit** | Option<**u32**> | Default 500; max 1000. |  |[default to 500]
-**trade_type** | Option<[**TradeTypeEnum**](.md)> | Type of trade. By default returns all. |  |
+**trade_type** | Option<[**TradeTypeEnum**](.md)> | Type of trade. By default returns all. UNSPECIFIED returns all. |  |
 **page** | Option<**u32**> | The page number to retrieve in a paginated response. |  |
 
 ### Return type

--- a/rust/gen/bluefin_api/docs/MarginTypeEnum.md
+++ b/rust/gen/bluefin_api/docs/MarginTypeEnum.md
@@ -6,6 +6,7 @@
 |---- | -----|
 | Cross | CROSS |
 | Isolated | ISOLATED |
+| Unspecified | UNSPECIFIED |
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/docs/PositionSideEnum.md
+++ b/rust/gen/bluefin_api/docs/PositionSideEnum.md
@@ -6,6 +6,7 @@
 |---- | -----|
 | Long | LONG |
 | Short | SHORT |
+| Unspecified | UNSPECIFIED |
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/docs/TradeSideEnum.md
+++ b/rust/gen/bluefin_api/docs/TradeSideEnum.md
@@ -6,6 +6,7 @@
 |---- | -----|
 | Long | LONG |
 | Short | SHORT |
+| Unspecified | UNSPECIFIED |
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/docs/TradeTypeEnum.md
+++ b/rust/gen/bluefin_api/docs/TradeTypeEnum.md
@@ -7,6 +7,7 @@
 | Order | ORDER |
 | Liquidation | LIQUIDATION |
 | Deleverage | DELEVERAGE |
+| Unspecified | UNSPECIFIED |
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/docs/TransactionTypeEnum.md
+++ b/rust/gen/bluefin_api/docs/TransactionTypeEnum.md
@@ -12,6 +12,7 @@
 | TradingFee | TRADING_FEE |
 | TradingGasFee | TRADING_GAS_FEE |
 | Bonus | BONUS |
+| Unspecified | UNSPECIFIED |
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/src/models/margin_type_enum.rs
+++ b/rust/gen/bluefin_api/src/models/margin_type_enum.rs
@@ -19,6 +19,8 @@ pub enum MarginTypeEnum {
     Cross,
     #[serde(rename = "ISOLATED")]
     Isolated,
+    #[serde(rename = "UNSPECIFIED")]
+    Unspecified,
 
 }
 
@@ -27,6 +29,7 @@ impl std::fmt::Display for MarginTypeEnum {
         match self {
             Self::Cross => write!(f, "CROSS"),
             Self::Isolated => write!(f, "ISOLATED"),
+            Self::Unspecified => write!(f, "UNSPECIFIED"),
         }
     }
 }

--- a/rust/gen/bluefin_api/src/models/position_side_enum.rs
+++ b/rust/gen/bluefin_api/src/models/position_side_enum.rs
@@ -19,6 +19,8 @@ pub enum PositionSideEnum {
     Long,
     #[serde(rename = "SHORT")]
     Short,
+    #[serde(rename = "UNSPECIFIED")]
+    Unspecified,
 
 }
 
@@ -27,6 +29,7 @@ impl std::fmt::Display for PositionSideEnum {
         match self {
             Self::Long => write!(f, "LONG"),
             Self::Short => write!(f, "SHORT"),
+            Self::Unspecified => write!(f, "UNSPECIFIED"),
         }
     }
 }

--- a/rust/gen/bluefin_api/src/models/trade.rs
+++ b/rust/gen/bluefin_api/src/models/trade.rs
@@ -93,6 +93,8 @@ pub enum TradingFeeAsset {
     Usdc,
     #[serde(rename = "BLUE")]
     Blue,
+    #[serde(rename = "UNSPECIFIED")]
+    Unspecified,
 }
 
 impl Default for TradingFeeAsset {

--- a/rust/gen/bluefin_api/src/models/trade_side_enum.rs
+++ b/rust/gen/bluefin_api/src/models/trade_side_enum.rs
@@ -19,6 +19,8 @@ pub enum TradeSideEnum {
     Long,
     #[serde(rename = "SHORT")]
     Short,
+    #[serde(rename = "UNSPECIFIED")]
+    Unspecified,
 
 }
 
@@ -27,6 +29,7 @@ impl std::fmt::Display for TradeSideEnum {
         match self {
             Self::Long => write!(f, "LONG"),
             Self::Short => write!(f, "SHORT"),
+            Self::Unspecified => write!(f, "UNSPECIFIED"),
         }
     }
 }

--- a/rust/gen/bluefin_api/src/models/trade_type_enum.rs
+++ b/rust/gen/bluefin_api/src/models/trade_type_enum.rs
@@ -21,6 +21,8 @@ pub enum TradeTypeEnum {
     Liquidation,
     #[serde(rename = "DELEVERAGE")]
     Deleverage,
+    #[serde(rename = "UNSPECIFIED")]
+    Unspecified,
 
 }
 
@@ -30,6 +32,7 @@ impl std::fmt::Display for TradeTypeEnum {
             Self::Order => write!(f, "ORDER"),
             Self::Liquidation => write!(f, "LIQUIDATION"),
             Self::Deleverage => write!(f, "DELEVERAGE"),
+            Self::Unspecified => write!(f, "UNSPECIFIED"),
         }
     }
 }

--- a/rust/gen/bluefin_api/src/models/transaction_type_enum.rs
+++ b/rust/gen/bluefin_api/src/models/transaction_type_enum.rs
@@ -31,6 +31,8 @@ pub enum TransactionTypeEnum {
     TradingGasFee,
     #[serde(rename = "BONUS")]
     Bonus,
+    #[serde(rename = "UNSPECIFIED")]
+    Unspecified,
 
 }
 
@@ -45,6 +47,7 @@ impl std::fmt::Display for TransactionTypeEnum {
             Self::TradingFee => write!(f, "TRADING_FEE"),
             Self::TradingGasFee => write!(f, "TRADING_GAS_FEE"),
             Self::Bonus => write!(f, "BONUS"),
+            Self::Unspecified => write!(f, "UNSPECIFIED"),
         }
     }
 }

--- a/ts/sdk/package.json
+++ b/ts/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/pro-sdk",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "OpenAPI client for @bluefin-exchange/pro-sdk",
   "author": "Bluefin",
   "repository": {

--- a/ts/sdk/src/api.ts
+++ b/ts/sdk/src/api.ts
@@ -1544,7 +1544,8 @@ export interface LoginResponse {
 
 export const MarginTypeEnum = {
     Cross: 'CROSS',
-    Isolated: 'ISOLATED'
+    Isolated: 'ISOLATED',
+    Unspecified: 'UNSPECIFIED'
 } as const;
 
 export type MarginTypeEnum = typeof MarginTypeEnum[keyof typeof MarginTypeEnum];
@@ -2730,7 +2731,8 @@ export interface Position {
 
 export const PositionSideEnum = {
     Long: 'LONG',
-    Short: 'SHORT'
+    Short: 'SHORT',
+    Unspecified: 'UNSPECIFIED'
 } as const;
 
 export type PositionSideEnum = typeof PositionSideEnum[keyof typeof PositionSideEnum];
@@ -3472,7 +3474,8 @@ export interface Trade {
 
 export const TradeTradingFeeAssetEnum = {
     Usdc: 'USDC',
-    Blue: 'BLUE'
+    Blue: 'BLUE',
+    Unspecified: 'UNSPECIFIED'
 } as const;
 
 export type TradeTradingFeeAssetEnum = typeof TradeTradingFeeAssetEnum[keyof typeof TradeTradingFeeAssetEnum];
@@ -3550,7 +3553,8 @@ export type TradeSide = typeof TradeSide[keyof typeof TradeSide];
 
 export const TradeSideEnum = {
     Long: 'LONG',
-    Short: 'SHORT'
+    Short: 'SHORT',
+    Unspecified: 'UNSPECIFIED'
 } as const;
 
 export type TradeSideEnum = typeof TradeSideEnum[keyof typeof TradeSideEnum];
@@ -3581,7 +3585,8 @@ export type TradeType = typeof TradeType[keyof typeof TradeType];
 export const TradeTypeEnum = {
     Order: 'ORDER',
     Liquidation: 'LIQUIDATION',
-    Deleverage: 'DELEVERAGE'
+    Deleverage: 'DELEVERAGE',
+    Unspecified: 'UNSPECIFIED'
 } as const;
 
 export type TradeTypeEnum = typeof TradeTypeEnum[keyof typeof TradeTypeEnum];
@@ -3695,7 +3700,8 @@ export const TransactionTypeEnum = {
     FundingFee: 'FUNDING_FEE',
     TradingFee: 'TRADING_FEE',
     TradingGasFee: 'TRADING_GAS_FEE',
-    Bonus: 'BONUS'
+    Bonus: 'BONUS',
+    Unspecified: 'UNSPECIFIED'
 } as const;
 
 export type TransactionTypeEnum = typeof TransactionTypeEnum[keyof typeof TransactionTypeEnum];
@@ -3851,7 +3857,7 @@ export const AccountDataApiAxiosParamCreator = function (configuration?: Configu
          * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
          * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
          * @param {number} [limit] Default 500; max 1000.
-         * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all.
+         * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all. UNSPECIFIED returns all.
          * @param {number} [page] The page number to retrieve in a paginated response.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4015,7 +4021,7 @@ export const AccountDataApiFp = function(configuration?: Configuration) {
          * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
          * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
          * @param {number} [limit] Default 500; max 1000.
-         * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all.
+         * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all. UNSPECIFIED returns all.
          * @param {number} [page] The page number to retrieve in a paginated response.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4079,7 +4085,7 @@ export const AccountDataApiFactory = function (configuration?: Configuration, ba
          * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
          * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
          * @param {number} [limit] Default 500; max 1000.
-         * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all.
+         * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all. UNSPECIFIED returns all.
          * @param {number} [page] The page number to retrieve in a paginated response.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4141,7 +4147,7 @@ export class AccountDataApi extends BaseAPI {
      * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
      * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
      * @param {number} [limit] Default 500; max 1000.
-     * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all.
+     * @param {TradeTypeEnum} [tradeType] Type of trade. By default returns all. UNSPECIFIED returns all.
      * @param {number} [page] The page number to retrieve in a paginated response.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}


### PR DESCRIPTION
update openapi definition and the openapi clients

For the following enums:
* TradeTypeEnum
* PositionSideEnum
* TradeSideEnum
* TransactionTypeEnum
* MarginTypeEnum
* Trade.tradingFeeAsset
