### PR TITLE
[BFP-1022] Rename Auth fields to be consistent with other part of the system

### DIFF
--- a/python/sdk/src/openapi_client/docs/LoginRequest.md
+++ b/python/sdk/src/openapi_client/docs/LoginRequest.md
@@ -7,7 +7,7 @@ User is expected to sign this payload and sends is signature in login api as hea
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **account_address** | **str** | The address of the account. | 
-**signed_at_utc_millis** | **int** | The timestamp in millis when the login was signed. | 
+**signed_at_millis** | **int** | The timestamp in millis when the login was signed. | 
 **audience** | **str** | The intended audience of the login request. | 
 
 ## Example

--- a/python/sdk/src/openapi_client/models/login_request.py
+++ b/python/sdk/src/openapi_client/models/login_request.py
@@ -27,9 +27,9 @@ class LoginRequest(BaseModel):
     User is expected to sign this payload and sends is signature in login api as header and payload itself in request body 
     """ # noqa: E501
     account_address: StrictStr = Field(description="The address of the account.", alias="accountAddress")
-    signed_at_utc_millis: StrictInt = Field(description="The timestamp in millis when the login was signed.", alias="signedAtUtcMillis")
+    signed_at_millis: StrictInt = Field(description="The timestamp in millis when the login was signed.", alias="signedAtMillis")
     audience: StrictStr = Field(description="The intended audience of the login request.")
-    __properties: ClassVar[List[str]] = ["accountAddress", "signedAtUtcMillis", "audience"]
+    __properties: ClassVar[List[str]] = ["accountAddress", "signedAtMillis", "audience"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -83,7 +83,7 @@ class LoginRequest(BaseModel):
 
         _obj = cls.model_validate({
             "accountAddress": obj.get("accountAddress"),
-            "signedAtUtcMillis": obj.get("signedAtUtcMillis"),
+            "signedAtMillis": obj.get("signedAtMillis"),
             "audience": obj.get("audience")
         })
         return _obj

--- a/resources/auth-api.yaml
+++ b/resources/auth-api.yaml
@@ -35,7 +35,7 @@ components:
         accountAddress:
           type: string
           description: The address of the account.
-        signedAtUtcMillis:
+        signedAtMillis:
           type: integer
           format: int64
           description: The timestamp in millis when the login was signed.
@@ -44,7 +44,7 @@ components:
           description: The intended audience of the login request.
       required:
         - accountAddress
-        - signedAtUtcMillis
+        - signedAtMillis
         - audience
     LoginResponse:
       type: object

--- a/rust/gen/bluefin_api/docs/LoginRequest.md
+++ b/rust/gen/bluefin_api/docs/LoginRequest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **account_address** | **String** | The address of the account. | 
-**signed_at_utc_millis** | **i64** | The timestamp in millis when the login was signed. | 
+**signed_at_millis** | **i64** | The timestamp in millis when the login was signed. | 
 **audience** | **String** | The intended audience of the login request. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/src/models/login_request.rs
+++ b/rust/gen/bluefin_api/src/models/login_request.rs
@@ -18,8 +18,8 @@ pub struct LoginRequest {
     #[serde(rename = "accountAddress")]
     pub account_address: String,
     /// The timestamp in millis when the login was signed.
-    #[serde(rename = "signedAtUtcMillis")]
-    pub signed_at_utc_millis: i64,
+    #[serde(rename = "signedAtMillis")]
+    pub signed_at_millis: i64,
     /// The intended audience of the login request.
     #[serde(rename = "audience")]
     pub audience: String,
@@ -27,10 +27,10 @@ pub struct LoginRequest {
 
 impl LoginRequest {
     /// User is expected to sign this payload and sends is signature in login api as header and payload itself in request body 
-    pub fn new(account_address: String, signed_at_utc_millis: i64, audience: String) -> LoginRequest {
+    pub fn new(account_address: String, signed_at_millis: i64, audience: String) -> LoginRequest {
         LoginRequest {
             account_address,
-            signed_at_utc_millis,
+            signed_at_millis,
             audience,
         }
     }

--- a/ts/sdk/package.json
+++ b/ts/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/pro-sdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "OpenAPI client for @bluefin-exchange/pro-sdk",
   "author": "Bluefin",
   "repository": {

--- a/ts/sdk/src/api.ts
+++ b/ts/sdk/src/api.ts
@@ -1497,7 +1497,7 @@ export interface LoginRequest {
      * @type {number}
      * @memberof LoginRequest
      */
-    'signedAtUtcMillis': number;
+    'signedAtMillis': number;
     /**
      * The intended audience of the login request.
      * @type {string}


### PR DESCRIPTION
signed_at_utc_millis to signed_at_millis