### PR TITLE
Update ts oapi config

### DIFF
--- a/ts/sdk/openapitools.json
+++ b/ts/sdk/openapitools.json
@@ -1,26 +1,19 @@
 {
-    "generator-cli": {
-        "version": "6.6.0",
-        "generators": {
-            "typescript-axios": {
-                "generatorName": "typescript-axios",
-                "additionalProperties": {
-                    "hideGenerationTimestamp": true,
-                    "avoidBoxedModels": true,
-                    "packageName": "bluefin-pro-api-client",
-                    "preferInterface": false,
-                    "typescriptThreePlus": true,
-                    "npmName": "@bluefin/api-client",
-                    "npmVersion": "1.0.0",
-                    "nullSafeAdditionalProps": true,
-                    "enumNameSuffix": "Enum",
-                    "modelPropertyNaming": "camelCase",
-                    "paramNaming": "camelCase",
-                    "sortParamsByRequiredFlag": true,
-                    "enablePostProcessFile": false,
-                    "generateAliasAsModel": true
-                }
-            }
-        }
-    }
+  "generatorName": "typescript-axios",
+  "additionalProperties": {
+    "hideGenerationTimestamp": true,
+    "avoidBoxedModels": true,
+    "packageName": "bluefin-pro-api-client",
+    "preferInterface": false,
+    "typescriptThreePlus": true,
+    "npmName": "@bluefin/api-client",
+    "npmVersion": "1.0.0",
+    "nullSafeAdditionalProps": true,
+    "enumNameSuffix": "Enum",
+    "modelPropertyNaming": "camelCase",
+    "paramNaming": "camelCase",
+    "sortParamsByRequiredFlag": true,
+    "enablePostProcessFile": false,
+    "generateAliasAsModel": true
+  }
 }


### PR DESCRIPTION
making sure the openapi-generator pick up the properties

Before in main, no code change happens if I update it to generate with snake case:

<img width="836" alt="Screenshot 2025-03-14 at 11 22 41 AM" src="https://github.com/user-attachments/assets/ec69662a-f845-41c7-822d-b0d29ec3b3e2" />

After the config update:

<img width="829" alt="Screenshot 2025-03-14 at 11 46 03 AM" src="https://github.com/user-attachments/assets/d8bc3ac7-c744-4b8a-9aca-8dad615fd431" />

We now have variables in snake case:
<img width="765" alt="Screenshot 2025-03-14 at 11 45 41 AM" src="https://github.com/user-attachments/assets/7bd147c6-4b27-4eab-bc08-59e8c09d7135" />
