### PR TITLE
[BFP-1144 Deposit Call Decimal Updates

### DIFF
--- a/python/sdk/src/crypto_helpers/rpc.py
+++ b/python/sdk/src/crypto_helpers/rpc.py
@@ -45,7 +45,7 @@ class ProRpcCalls:
         Args:
 
             coin_symbol (str): The symbol of the coin being deposited
-            amount (uint): The amount to be deposited
+            amount (uint): The amount to be deposited in the units of the coin being deposited (for example, 1 USDC == 1000000)
             destination (str): Optional destination account to which funds are being deposited.
                                By default, funds are always deposited to the depositor's account
 

--- a/python/sdk/src/crypto_helpers/utils.py
+++ b/python/sdk/src/crypto_helpers/utils.py
@@ -196,7 +196,6 @@ def get_coin_having_balance(user_address: str = None, coin_type: str = "0x::sui:
         coin_list = get_coins(user_address, coin_type, url)
         
         for coin in coin_list:
-            print(coin["balance"], balance, int(coin["balance"]) >= balance, exact_match)
             if exact_match:
                  if int(coin["balance"]) == int(balance):
                       return coin["coinObjectId"]

--- a/python/sdk/tests/test_rpc_calls.py
+++ b/python/sdk/tests/test_rpc_calls.py
@@ -32,7 +32,9 @@ pro_rpc_calls = ProRpcCalls(
 @pytest.mark.asyncio
 async def test_deposit():
     
-    # USDC amount is in 1e6
+    # USDC amount is in 6 decimal places
+    # 0.15 USDC == 150000
+    
     success, _ = pro_rpc_calls.deposit_to_asset_bank("USDC", 1500)
 
     assert success == True


### PR DESCRIPTION
### **User description**
Added code comments to make it clear that the input amount to `deposit_to_asset_bank` is in decimals of the coin being deposited.


___

### **PR Type**
Documentation, Tests


___

### **Description**
- Clarified the unit of `amount` in `deposit_to_asset_bank` method.

- Updated test comments to specify decimal places for USDC.

- Removed unnecessary debug print statement in `get_coin_having_balance`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc.py</strong><dd><code>Clarified `amount` units in `deposit_to_asset_bank` docstring</code></dd></summary>
<hr>

python/sdk/src/crypto_helpers/rpc.py

<li>Updated the docstring for <code>deposit_to_asset_bank</code> to specify that the <br><code>amount</code> is in the smallest units of the coin.


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/38/files#diff-b549e74204e9ec7f9d58dc1d87d0bd06b5d92a8828380af98cf1c05de23dd718">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Removed debug print statement in utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/sdk/src/crypto_helpers/utils.py

- Removed a debug print statement from `get_coin_having_balance`.


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/38/files#diff-eccaf00fdf995f84e4c5cd3271a0fbc06bc0cb927766a5be19d6b5800e2faef5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_rpc_calls.py</strong><dd><code>Updated test comments for USDC decimal places</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/sdk/tests/test_rpc_calls.py

<li>Updated test comments to specify that USDC uses 6 decimal places.<br> <li> Added an example for 0.15 USDC in the test comment.


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/38/files#diff-2e74e06d2a9b5fdcd9a91bdddf7a6cb7407c83886954695f393facb7d15e0b13">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>