### PR TITLE
[BFP-1281] Update GET /account/trades symbol parameter to be optional

### DIFF
--- a/python/sdk/src/openapi_client/api/account_data_api.py
+++ b/python/sdk/src/openapi_client/api/account_data_api.py
@@ -864,7 +864,7 @@ class AccountDataApi:
     @validate_call
     async def get_account_trades(
         self,
-        symbol: Annotated[StrictStr, Field(description="Market address to filter trades by.")],
+        symbol: Annotated[Optional[StrictStr], Field(description="Market address to filter trades by. If not specified, returns trades for all markets.")] = None,
         start_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Start time in milliseconds. Defaults to 7 days ago if not specified.")] = None,
         end_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]], Field(description="Default 500; max 1000.")] = None,
@@ -886,7 +886,7 @@ class AccountDataApi:
         """Get user's trade history.
 
 
-        :param symbol: Market address to filter trades by. (required)
+        :param symbol: Market address to filter trades by. If not specified, returns trades for all markets.
         :type symbol: str
         :param start_time_at_millis: Start time in milliseconds. Defaults to 7 days ago if not specified.
         :type start_time_at_millis: int
@@ -954,7 +954,7 @@ class AccountDataApi:
     @validate_call
     async def get_account_trades_with_http_info(
         self,
-        symbol: Annotated[StrictStr, Field(description="Market address to filter trades by.")],
+        symbol: Annotated[Optional[StrictStr], Field(description="Market address to filter trades by. If not specified, returns trades for all markets.")] = None,
         start_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Start time in milliseconds. Defaults to 7 days ago if not specified.")] = None,
         end_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]], Field(description="Default 500; max 1000.")] = None,
@@ -976,7 +976,7 @@ class AccountDataApi:
         """Get user's trade history.
 
 
-        :param symbol: Market address to filter trades by. (required)
+        :param symbol: Market address to filter trades by. If not specified, returns trades for all markets.
         :type symbol: str
         :param start_time_at_millis: Start time in milliseconds. Defaults to 7 days ago if not specified.
         :type start_time_at_millis: int
@@ -1044,7 +1044,7 @@ class AccountDataApi:
     @validate_call
     async def get_account_trades_without_preload_content(
         self,
-        symbol: Annotated[StrictStr, Field(description="Market address to filter trades by.")],
+        symbol: Annotated[Optional[StrictStr], Field(description="Market address to filter trades by. If not specified, returns trades for all markets.")] = None,
         start_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Start time in milliseconds. Defaults to 7 days ago if not specified.")] = None,
         end_time_at_millis: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]], Field(description="Default 500; max 1000.")] = None,
@@ -1066,7 +1066,7 @@ class AccountDataApi:
         """Get user's trade history.
 
 
-        :param symbol: Market address to filter trades by. (required)
+        :param symbol: Market address to filter trades by. If not specified, returns trades for all markets.
         :type symbol: str
         :param start_time_at_millis: Start time in milliseconds. Defaults to 7 days ago if not specified.
         :type start_time_at_millis: int

--- a/python/sdk/src/openapi_client/docs/AccountDataApi.md
+++ b/python/sdk/src/openapi_client/docs/AccountDataApi.md
@@ -248,7 +248,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_account_trades**
-> List[Trade] get_account_trades(symbol, start_time_at_millis=start_time_at_millis, end_time_at_millis=end_time_at_millis, limit=limit, trade_type=trade_type, page=page)
+> List[Trade] get_account_trades(symbol=symbol, start_time_at_millis=start_time_at_millis, end_time_at_millis=end_time_at_millis, limit=limit, trade_type=trade_type, page=page)
 
 Get user's trade history.
 
@@ -283,7 +283,7 @@ configuration = openapi_client.Configuration(
 async with openapi_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = openapi_client.AccountDataApi(api_client)
-    symbol = 'symbol_example' # str | Market address to filter trades by.
+    symbol = 'symbol_example' # str | Market address to filter trades by. If not specified, returns trades for all markets. (optional)
     start_time_at_millis = 56 # int | Start time in milliseconds. Defaults to 7 days ago if not specified. (optional)
     end_time_at_millis = 56 # int | End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart. (optional)
     limit = 500 # int | Default 500; max 1000. (optional) (default to 500)
@@ -292,7 +292,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
 
     try:
         # Get user's trade history.
-        api_response = await api_instance.get_account_trades(symbol, start_time_at_millis=start_time_at_millis, end_time_at_millis=end_time_at_millis, limit=limit, trade_type=trade_type, page=page)
+        api_response = await api_instance.get_account_trades(symbol=symbol, start_time_at_millis=start_time_at_millis, end_time_at_millis=end_time_at_millis, limit=limit, trade_type=trade_type, page=page)
         print("The response of AccountDataApi->get_account_trades:\n")
         pprint(api_response)
     except Exception as e:
@@ -306,7 +306,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **symbol** | **str**| Market address to filter trades by. | 
+ **symbol** | **str**| Market address to filter trades by. If not specified, returns trades for all markets. | [optional] 
  **start_time_at_millis** | **int**| Start time in milliseconds. Defaults to 7 days ago if not specified. | [optional] 
  **end_time_at_millis** | **int**| End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart. | [optional] 
  **limit** | **int**| Default 500; max 1000. | [optional] [default to 500]

--- a/resources/account-data-api.yaml
+++ b/resources/account-data-api.yaml
@@ -448,10 +448,9 @@ paths:
       parameters:
         - name: symbol
           in: query
-          required: true
           schema:
             type: string
-          description: Market address to filter trades by.
+          description: Market address to filter trades by. If not specified, returns trades for all markets.
         - name: startTimeAtMillis
           in: query
           required: false

--- a/rust/examples/account-trades.rs
+++ b/rust/examples/account-trades.rs
@@ -9,7 +9,7 @@ type Error = Box<dyn std::error::Error>;
 type Result<T> = std::result::Result<T, Error>;
 
 /// Sends a request for account trades, and returns the deserialized response.
-async fn send_request(auth_token: &str, symbol: &str) -> Result<Vec<Trade>> {
+async fn send_request(auth_token: &str, symbol: Option<&str>) -> Result<Vec<Trade>> {
     println!("Sending request...");
     Ok(get_account_trades(
         &Configuration {
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         .await?
         .access_token;
 
-    let trades = send_request(&auth_token, symbols::perps::ETH).await?;
+    let trades = send_request(&auth_token, Some(symbols::perps::ETH)).await?;
 
     println!("{trades:#?}");
 

--- a/rust/gen/bluefin_api/docs/AccountDataApi.md
+++ b/rust/gen/bluefin_api/docs/AccountDataApi.md
@@ -102,7 +102,7 @@ Get user's trade history.
 
 Name | Type | Description  | Required | Notes
 ------------- | ------------- | ------------- | ------------- | -------------
-**symbol** | **String** | Market address to filter trades by. | [required] |
+**symbol** | Option<**String**> | Market address to filter trades by. If not specified, returns trades for all markets. |  |
 **start_time_at_millis** | Option<**u32**> | Start time in milliseconds. Defaults to 7 days ago if not specified. |  |
 **end_time_at_millis** | Option<**u32**> | End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart. |  |
 **limit** | Option<**u32**> | Default 500; max 1000. |  |[default to 500]

--- a/rust/gen/bluefin_api/src/apis/account_data_api.rs
+++ b/rust/gen/bluefin_api/src/apis/account_data_api.rs
@@ -165,7 +165,7 @@ pub async fn get_account_preferences(configuration: &configuration::Configuratio
     }
 }
 
-pub async fn get_account_trades(configuration: &configuration::Configuration, symbol: &str, start_time_at_millis: Option<u32>, end_time_at_millis: Option<u32>, limit: Option<u32>, trade_type: Option<models::TradeType>, page: Option<u32>) -> Result<Vec<models::Trade>, Error<GetAccountTradesError>> {
+pub async fn get_account_trades(configuration: &configuration::Configuration, symbol: Option<&str>, start_time_at_millis: Option<u32>, end_time_at_millis: Option<u32>, limit: Option<u32>, trade_type: Option<models::TradeType>, page: Option<u32>) -> Result<Vec<models::Trade>, Error<GetAccountTradesError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_symbol = symbol;
     let p_start_time_at_millis = start_time_at_millis;
@@ -177,7 +177,9 @@ pub async fn get_account_trades(configuration: &configuration::Configuration, sy
     let uri_str = format!("{}/api/v1/account/trades", configuration.base_path);
     let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
 
-    req_builder = req_builder.query(&[("symbol", &p_symbol.to_string())]);
+    if let Some(ref param_value) = p_symbol {
+        req_builder = req_builder.query(&[("symbol", &param_value.to_string())]);
+    }
     if let Some(ref param_value) = p_start_time_at_millis {
         req_builder = req_builder.query(&[("startTimeAtMillis", &param_value.to_string())]);
     }

--- a/ts/sdk/example.ts
+++ b/ts/sdk/example.ts
@@ -111,18 +111,15 @@ async function main() {
   await client.initialize();
 
   try {
-    await client.deposit("1000");
+    // Disable for now as the account does not have enough coins
+    // await client.deposit((0.03*1e9).toString());
+
     // Get Market Data from Exchange Data API
     const exchangeInfo = (await client.exchangeDataApi.getExchangeInfo()).data;
     logger.info(`Exchange Info: ${JSON.stringify(exchangeInfo)}`);
 
-    // Find SUI-PERP market
-    const perpMarket = exchangeInfo.markets.find(
-      (m: Market) => m.symbol === "SUI-PERP",
-    );
-    if (!perpMarket) {
-      throw new Error("SUI-PERP market not found");
-    }
+    // Find the first market available if any
+    const perpMarket = exchangeInfo.markets.length > 0 ? exchangeInfo.markets[0] : (() => { throw new Error("No market is available"); })();
     logger.info(`Selected market: ${JSON.stringify(perpMarket)}`);
 
     const symbol = perpMarket.symbol;

--- a/ts/sdk/src/api.ts
+++ b/ts/sdk/src/api.ts
@@ -3704,7 +3704,7 @@ export const AccountDataApiAxiosParamCreator = function (configuration?: Configu
         /**
          * 
          * @summary Get user\'s trade history.
-         * @param {string} symbol Market address to filter trades by.
+         * @param {string} [symbol] Market address to filter trades by. If not specified, returns trades for all markets.
          * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
          * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
          * @param {number} [limit] Default 500; max 1000.
@@ -3713,9 +3713,7 @@ export const AccountDataApiAxiosParamCreator = function (configuration?: Configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAccountTrades: async (symbol: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'symbol' is not null or undefined
-            assertParamExists('getAccountTrades', 'symbol', symbol)
+        getAccountTrades: async (symbol?: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/api/v1/account/trades`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3883,7 +3881,7 @@ export const AccountDataApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Get user\'s trade history.
-         * @param {string} symbol Market address to filter trades by.
+         * @param {string} [symbol] Market address to filter trades by. If not specified, returns trades for all markets.
          * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
          * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
          * @param {number} [limit] Default 500; max 1000.
@@ -3892,7 +3890,7 @@ export const AccountDataApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAccountTrades(symbol: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Trade>>> {
+        async getAccountTrades(symbol?: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Trade>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getAccountTrades(symbol, startTimeAtMillis, endTimeAtMillis, limit, tradeType, page, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['AccountDataApi.getAccountTrades']?.[localVarOperationServerIndex]?.url;
@@ -3959,7 +3957,7 @@ export const AccountDataApiFactory = function (configuration?: Configuration, ba
         /**
          * 
          * @summary Get user\'s trade history.
-         * @param {string} symbol Market address to filter trades by.
+         * @param {string} [symbol] Market address to filter trades by. If not specified, returns trades for all markets.
          * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
          * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
          * @param {number} [limit] Default 500; max 1000.
@@ -3968,7 +3966,7 @@ export const AccountDataApiFactory = function (configuration?: Configuration, ba
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAccountTrades(symbol: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options?: RawAxiosRequestConfig): AxiosPromise<Array<Trade>> {
+        getAccountTrades(symbol?: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options?: RawAxiosRequestConfig): AxiosPromise<Array<Trade>> {
             return localVarFp.getAccountTrades(symbol, startTimeAtMillis, endTimeAtMillis, limit, tradeType, page, options).then((request) => request(axios, basePath));
         },
         /**
@@ -4035,7 +4033,7 @@ export class AccountDataApi extends BaseAPI {
     /**
      * 
      * @summary Get user\'s trade history.
-     * @param {string} symbol Market address to filter trades by.
+     * @param {string} [symbol] Market address to filter trades by. If not specified, returns trades for all markets.
      * @param {number} [startTimeAtMillis] Start time in milliseconds. Defaults to 7 days ago if not specified.
      * @param {number} [endTimeAtMillis] End time in milliseconds. Defaults to now if not specified. Must be greater than start time and must be less than 7 days apart.
      * @param {number} [limit] Default 500; max 1000.
@@ -4045,7 +4043,7 @@ export class AccountDataApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof AccountDataApi
      */
-    public getAccountTrades(symbol: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options?: RawAxiosRequestConfig) {
+    public getAccountTrades(symbol?: string, startTimeAtMillis?: number, endTimeAtMillis?: number, limit?: number, tradeType?: TradeType, page?: number, options?: RawAxiosRequestConfig) {
         return AccountDataApiFp(this.configuration).getAccountTrades(symbol, startTimeAtMillis, endTimeAtMillis, limit, tradeType, page, options).then((request) => request(this.axios, this.basePath));
     }
 


### PR DESCRIPTION
### **User description**
so that we can fetch trades from all symbols


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Made the `symbol` parameter optional in `GET /account/trades` API.
  - Allows fetching trades across all markets when `symbol` is not specified.

- Updated SDKs (TypeScript, Rust, Python) to reflect the optional `symbol` parameter.

- Adjusted examples in SDKs to align with the updated API behavior.

- Updated documentation to clarify the optional nature of the `symbol` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>example.ts</strong><dd><code>Adjusted example to handle optional `symbol` parameter.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-be448d6f005bc6f67ac14b0a670882b37116646a25dd8bb00db34bf0ad877da3">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.ts</strong><dd><code>Made `symbol` parameter optional in TypeScript SDK.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-c8372d5ed2306ce6a30abfa8c4cff8d92ff874216c8773d3d3b4801e908730e1">+8/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account-trades.rs</strong><dd><code>Updated Rust example to handle optional `symbol`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-27ffe631f443ca1f370f832fddf470589efb3c0489f9a5833b9106ba1f954862">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account_data_api.rs</strong><dd><code>Made `symbol` parameter optional in Rust SDK.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-c30d160c85a78a9e0e78f48d11f0319448418cc5860d08c184205ad743d2961c">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account_data_api.py</strong><dd><code>Made `symbol` parameter optional in Python SDK.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-9c75e49327a7f62d7d95039ab8eb4ceb4d83fea104748adb98cd815999178682">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AccountDataApi.md</strong><dd><code>Updated Python SDK documentation for optional `symbol`.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-d9e1b2b6ded2f9f16c03aedcde1e336adb78480ae91320df0849ce002ef04074">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account-data-api.yaml</strong><dd><code>Updated OpenAPI spec to make `symbol` optional.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-2718608e39836c994789f8869804bf058351325dae3af3a8576c71d3bb5836f9">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AccountDataApi.md</strong><dd><code>Updated Rust SDK documentation for optional `symbol`.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/42/files#diff-bdc0fa1559b9487bcada0c35cf12f2405cbf1b3abc020efd9cd2c35729263b73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>