### PR TITLE
[BFP-1288] Remove AccountPositionUpdate.maxNotionalValueE9 from WS

### DIFF
--- a/python/sdk/src/openapi_client/docs/AccountPositionUpdate.md
+++ b/python/sdk/src/openapi_client/docs/AccountPositionUpdate.md
@@ -12,7 +12,6 @@ Name | Type | Description | Notes
 **liquidation_price_e9** | **str** | The liquidation price of the position. | 
 **mark_price_e9** | **str** | The current mark price of the position. | 
 **notional_value_e9** | **str** | The notional value of the position. | 
-**max_notional_value_e9** | **str** | The maximum notional value for the position. | 
 **size_e9** | **str** | The size of the position. | 
 **unrealized_pnl_e9** | **str** | The unrealized profit and loss for the position. | 
 **side** | [**Side**](Side.md) |  | 

--- a/python/sdk/src/openapi_client/docs/AccountStreamMessagePayload.md
+++ b/python/sdk/src/openapi_client/docs/AccountStreamMessagePayload.md
@@ -62,7 +62,6 @@ Name | Type | Description | Notes
 **liquidation_price_e9** | **str** | The liquidation price of the position. | 
 **mark_price_e9** | **str** | The current mark price of the position. | 
 **notional_value_e9** | **str** | The notional value of the position. | 
-**max_notional_value_e9** | **str** | The maximum notional value for the position. | 
 **size_e9** | **str** | The size of the position. | 
 **unrealized_pnl_e9** | **str** | The unrealized profit and loss for the position. | 
 **initial_margin_e9** | **str** | The initial margin required for the position. | 

--- a/python/sdk/src/openapi_client/models/account_position_update.py
+++ b/python/sdk/src/openapi_client/models/account_position_update.py
@@ -33,7 +33,6 @@ class AccountPositionUpdate(BaseModel):
     liquidation_price_e9: StrictStr = Field(description="The liquidation price of the position.", alias="liquidationPriceE9")
     mark_price_e9: StrictStr = Field(description="The current mark price of the position.", alias="markPriceE9")
     notional_value_e9: StrictStr = Field(description="The notional value of the position.", alias="notionalValueE9")
-    max_notional_value_e9: StrictStr = Field(description="The maximum notional value for the position.", alias="maxNotionalValueE9")
     size_e9: StrictStr = Field(description="The size of the position.", alias="sizeE9")
     unrealized_pnl_e9: StrictStr = Field(description="The unrealized profit and loss for the position.", alias="unrealizedPnlE9")
     side: Side
@@ -42,7 +41,7 @@ class AccountPositionUpdate(BaseModel):
     is_isolated: StrictBool = Field(description="Indicates if the position is isolated.", alias="isIsolated")
     isolated_margin_e9: StrictStr = Field(description="The isolated margin applied to the position.", alias="isolatedMarginE9")
     updated_at_millis: StrictInt = Field(description="The last update time for the position in milliseconds.", alias="updatedAtMillis")
-    __properties: ClassVar[List[str]] = ["symbol", "avgEntryPriceE9", "leverageE9", "liquidationPriceE9", "markPriceE9", "notionalValueE9", "maxNotionalValueE9", "sizeE9", "unrealizedPnlE9", "side", "initialMarginE9", "maintenanceMarginE9", "isIsolated", "isolatedMarginE9", "updatedAtMillis"]
+    __properties: ClassVar[List[str]] = ["symbol", "avgEntryPriceE9", "leverageE9", "liquidationPriceE9", "markPriceE9", "notionalValueE9", "sizeE9", "unrealizedPnlE9", "side", "initialMarginE9", "maintenanceMarginE9", "isIsolated", "isolatedMarginE9", "updatedAtMillis"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,7 +100,6 @@ class AccountPositionUpdate(BaseModel):
             "liquidationPriceE9": obj.get("liquidationPriceE9"),
             "markPriceE9": obj.get("markPriceE9"),
             "notionalValueE9": obj.get("notionalValueE9"),
-            "maxNotionalValueE9": obj.get("maxNotionalValueE9"),
             "sizeE9": obj.get("sizeE9"),
             "unrealizedPnlE9": obj.get("unrealizedPnlE9"),
             "side": obj.get("side"),

--- a/resources/websocket-api.yaml
+++ b/resources/websocket-api.yaml
@@ -459,9 +459,6 @@ components:
         notionalValueE9:
           type: string
           description: "The notional value of the position."
-        maxNotionalValueE9:
-          type: string
-          description: "The maximum notional value for the position."
         sizeE9:
           type: string
           description: "The size of the position."
@@ -493,7 +490,6 @@ components:
         - liquidationPriceE9
         - markPriceE9
         - notionalValueE9
-        - maxNotionalValueE9
         - sizeE9
         - unrealizedPnlE9
         - side

--- a/rust/gen/bluefin_api/docs/AccountPositionUpdate.md
+++ b/rust/gen/bluefin_api/docs/AccountPositionUpdate.md
@@ -10,7 +10,6 @@ Name | Type | Description | Notes
 **liquidation_price_e9** | **String** | The liquidation price of the position. | 
 **mark_price_e9** | **String** | The current mark price of the position. | 
 **notional_value_e9** | **String** | The notional value of the position. | 
-**max_notional_value_e9** | **String** | The maximum notional value for the position. | 
 **size_e9** | **String** | The size of the position. | 
 **unrealized_pnl_e9** | **String** | The unrealized profit and loss for the position. | 
 **side** | [**models::Side**](Side.md) |  | 

--- a/rust/gen/bluefin_api/src/models/account_position_update.rs
+++ b/rust/gen/bluefin_api/src/models/account_position_update.rs
@@ -32,9 +32,6 @@ pub struct AccountPositionUpdate {
     /// The notional value of the position.
     #[serde(rename = "notionalValueE9")]
     pub notional_value_e9: String,
-    /// The maximum notional value for the position.
-    #[serde(rename = "maxNotionalValueE9")]
-    pub max_notional_value_e9: String,
     /// The size of the position.
     #[serde(rename = "sizeE9")]
     pub size_e9: String,
@@ -62,7 +59,7 @@ pub struct AccountPositionUpdate {
 
 impl AccountPositionUpdate {
     /// Details about an account position update.
-    pub fn new(symbol: String, avg_entry_price_e9: String, leverage_e9: String, liquidation_price_e9: String, mark_price_e9: String, notional_value_e9: String, max_notional_value_e9: String, size_e9: String, unrealized_pnl_e9: String, side: models::Side, initial_margin_e9: String, maintenance_margin_e9: String, is_isolated: bool, isolated_margin_e9: String, updated_at_millis: i64) -> AccountPositionUpdate {
+    pub fn new(symbol: String, avg_entry_price_e9: String, leverage_e9: String, liquidation_price_e9: String, mark_price_e9: String, notional_value_e9: String, size_e9: String, unrealized_pnl_e9: String, side: models::Side, initial_margin_e9: String, maintenance_margin_e9: String, is_isolated: bool, isolated_margin_e9: String, updated_at_millis: i64) -> AccountPositionUpdate {
         AccountPositionUpdate {
             symbol,
             avg_entry_price_e9,
@@ -70,7 +67,6 @@ impl AccountPositionUpdate {
             liquidation_price_e9,
             mark_price_e9,
             notional_value_e9,
-            max_notional_value_e9,
             size_e9,
             unrealized_pnl_e9,
             side,

--- a/ts/sdk/src/api.ts
+++ b/ts/sdk/src/api.ts
@@ -424,12 +424,6 @@ export interface AccountPositionUpdate {
      */
     'notionalValueE9': string;
     /**
-     * The maximum notional value for the position.
-     * @type {string}
-     * @memberof AccountPositionUpdate
-     */
-    'maxNotionalValueE9': string;
-    /**
      * The size of the position.
      * @type {string}
      * @memberof AccountPositionUpdate


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Removed `maxNotionalValueE9` field from `AccountPositionUpdate` across multiple SDKs.

- Updated related documentation to reflect the removal.

- Adjusted constructors and serialization logic to exclude `maxNotionalValueE9`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>api.ts</strong><dd><code>Removed `maxNotionalValueE9` field from TypeScript SDK.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-c8372d5ed2306ce6a30abfa8c4cff8d92ff874216c8773d3d3b4801e908730e1">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account_position_update.rs</strong><dd><code>Removed `maxNotionalValueE9` field from Rust SDK model.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-f12854544d6f2b92d34cf2dc1b4babaf5f62d5a8742d2d4185de0ff26364de9b">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account_position_update.py</strong><dd><code>Removed `maxNotionalValueE9` field from Python SDK model.</code></dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-b115f6a5fc4a836a26353f85359abf677cd3a1b152257bb99a0b83029415bece">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>websocket-api.yaml</strong><dd><code>Removed `maxNotionalValueE9` field from WebSocket API schema.</code></dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-9b83bfd9f25c44477ddd31c9091e94aee80d678637f87288398982eae7dcacc7">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AccountPositionUpdate.md</strong><dd><code>Updated Python SDK documentation to remove `maxNotionalValueE9`.</code></dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-b940a936d6e26ebd87f90ac6746964b1e7fd965b0a87d2d8fd9edcfd7215e04c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AccountStreamMessagePayload.md</strong><dd><code>Updated Python SDK stream message documentation to remove </code><br><code><code>maxNotionalValueE9</code>.</code></dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-1c480cc6559a188c867e3c5a70fc20232d3fc9fd2bedf4c56ee0851c4fc7eb85">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AccountPositionUpdate.md</strong><dd><code>Updated Rust SDK documentation to remove `maxNotionalValueE9`.</code></dd></td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/44/files#diff-1e408a73aee8ac2b75b7ce32ac0d09003801e25e6344f996029f292a7bd8ecf1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>