### PR TITLE
fixup apigen to check for npm and openapi generator installation

### DIFF
--- a/rust/src/bin/apigen.rs
+++ b/rust/src/bin/apigen.rs
@@ -16,8 +16,11 @@ use std::{env, fmt, io};
 /// Name of the directory where OpenAPI YAML specs live.
 const INPUT_DIR: &str = "resources";
 
-const USAGE: &str = "apigen { -l } { rust | python | ts }. 
-Please ensure that npm and openapi-generator-cli are installed following the instructions at https://openapi-generator.tech/docs/installation";
+const USAGE: &str = "apigen { -l } { rust | python | ts }
+
+Please ensure that npm and openapi-generator-cli are installed following the instructions at:
+https://openapi-generator.tech/docs/installation
+";
 
 #[derive(Debug)]
 pub enum Error {
@@ -194,6 +197,11 @@ fn main_imp() -> Result<()> {
         match arg.as_str() {
             "-h" | "--help" => {
                 println!("usage: {USAGE}");
+                let args = args.collect::<Vec<_>>();
+                if !args.is_empty() {
+                    eprintln!("warning: ignoring args: {args:?}");
+                }
+                return Ok(());
             }
             "-l" | "--lang" => lang = Some(args.next().ok_or(Error::Flag(arg))?.parse()?),
             _ => return Err(Error::Flag(arg)),


### PR DESCRIPTION
### **User description**
- Fixup apigen to check if npm and openapi-generator-cli are installed prior to run and provide instructions on how to install when running apigen -h


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added checks for `npm` and `openapi-generator-cli` installation.

- Updated usage instructions to include installation guidance.

- Ensured `openapi-generator-cli` version is set to 7.11.0.

- Improved error handling for missing dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apigen.rs</strong><dd><code>Enhance apigen with dependency checks and version management</code></dd></summary>
<hr>

rust/src/bin/apigen.rs

<li>Added checks for <code>npm</code> and <code>openapi-generator-cli</code> installation.<br> <li> Updated usage instructions with installation guidance.<br> <li> Set <code>openapi-generator-cli</code> version to 7.11.0.<br> <li> Improved error handling for dependency checks.


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/49/files#diff-e158dec9599be69eafd3511ee8fb6efeeb7c7137f24ec4eeeb63a67a65a4e067">+41/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>