### PR TITLE
Work around apparent OpenAPI license syntax change

### DIFF
--- a/resources/bluefin-api.yaml
+++ b/resources/bluefin-api.yaml
@@ -206,6 +206,6 @@ info:
   # The "identifier" key is not supported by all versions of the OpenAPI generator,
   # but the commented SPDX license expression is accurate.
   license:
-    name: "MIT or Apache 2.0"
+    name: "MIT OR Apache-2.0"
     # identifier: "MIT OR Apache-2.0"
     url: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/rust/gen/bluefin_api/Cargo.toml
+++ b/rust/gen/bluefin_api/Cargo.toml
@@ -3,7 +3,7 @@ name = "bluefin_api"
 version = "1.0.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "Bluefin API"
-license = "MIT or Apache 2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Some versions of the OpenAPI generator apparently using the license.name from YAML as the license value in Cargo.toml. That's bad, because the latter must be a valid SPDX license expression. The latest generator versions apparently fixes this, adding a license.identifier field as an alternative to license.url; but we still need compatibility with the older version.