### PR TITLE
BFP-1983: Deprecated inconsistent naming

### DIFF
--- a/rust/examples/account-details.rs
+++ b/rust/examples/account-details.rs
@@ -7,11 +7,11 @@ type Error = Box<dyn std::error::Error>;
 type Result<T> = std::result::Result<T, Error>;
 
 /// Sends a request for account details, and returns the deserialized response.
-async fn send_request(account_address: &str) -> Result<Account> {
+async fn send_request(account_address: &str, environment: Environment) -> Result<Account> {
     println!("Sending request...");
     Ok(get_account_details(
         &Configuration {
-            base_path: account::testnet::URL.into(),
+            base_path: account::url(environment).to_string(),
             ..Configuration::new()
         },
         Some(account_address),
@@ -21,7 +21,9 @@ async fn send_request(account_address: &str) -> Result<Account> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let account = send_request(test::account::testnet::ADDRESS).await?;
+    let environment = Environment::Staging;
+    let test_account_address = test::account::address(environment);
+    let account = send_request(test_account_address, environment).await?;
 
     println!("{account:#?}");
 

--- a/rust/examples/account-funding-rate-history.rs
+++ b/rust/examples/account-funding-rate-history.rs
@@ -27,19 +27,21 @@ async fn send_request(auth_token: &str) -> Result<AccountFundingRateHistory> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
+    let test_account_address = test::account::address(environment);
     let login_request = LoginRequest::new(
-        test::account::testnet::ADDRESS.into(),
+        test_account_address.into(),
         Utc::now().timestamp_millis(),
-        auth::testnet::AUDIENCE.into(),
+        auth::audience(environment).into(),
     );
 
     let signature = login_request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     let auth_token = login_request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 

--- a/rust/examples/account-preferences.rs
+++ b/rust/examples/account-preferences.rs
@@ -23,19 +23,21 @@ async fn send_request(auth_token: &str) -> Result<AccountPreference> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
+    let test_account_address = test::account::address(environment);
     let login_request = LoginRequest::new(
-        test::account::testnet::ADDRESS.into(),
+        test_account_address.into(),
         Utc::now().timestamp_millis(),
-        auth::testnet::AUDIENCE.into(),
+        auth::audience(environment).into(),
     );
 
     let signature = login_request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     let auth_token = login_request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 

--- a/rust/examples/account-trades.rs
+++ b/rust/examples/account-trades.rs
@@ -29,23 +29,25 @@ async fn send_request(auth_token: &str, symbol: Option<&str>) -> Result<Vec<Trad
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
+    let test_account_address = test::account::address(environment);
     let login_request = LoginRequest::new(
-        test::account::testnet::ADDRESS.into(),
+        test_account_address.into(),
         Utc::now().timestamp_millis(),
-        auth::testnet::AUDIENCE.into(),
+        auth::audience(environment).into(),
     );
 
     let signature = login_request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     let auth_token = login_request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 
-    let trades = send_request(&auth_token, Some(symbols::perps::ETH)).await?;
+    let trades = send_request(&auth_token, Some("ETH-PERP")).await?;
 
     println!("{trades:#?}");
 

--- a/rust/examples/exchange-candlesticks.rs
+++ b/rust/examples/exchange-candlesticks.rs
@@ -8,12 +8,13 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_candlestick_data(
         &Configuration {
-            base_path: exchange::testnet::URL.into(),
+            base_path: exchange::url(environment).into(),
             ..Configuration::default()
         },
-        symbols::perps::ETH,       // symbol
+        "ETH-PERP",                // symbol
         KlineInterval::Variant12h, // interval
         CandlePriceType::Last,     // type
         None,                      // start_time_at_millis

--- a/rust/examples/exchange-depth.rs
+++ b/rust/examples/exchange-depth.rs
@@ -7,13 +7,14 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_orderbook_depth(
         &Configuration {
-            base_path: exchange::testnet::URL.into(),
+            base_path: exchange::url(environment).into(),
             ..Configuration::default()
         },
-        symbols::perps::ETH, // symbol
-        Some(5),             // limit
+        "ETH-PERP", // symbol
+        Some(5),    // limit
     )
     .await?;
 

--- a/rust/examples/exchange-funding-rate-history.rs
+++ b/rust/examples/exchange-funding-rate-history.rs
@@ -7,16 +7,17 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_funding_rate_history(
         &Configuration {
-            base_path: exchange::testnet::URL.into(),
+            base_path: exchange::url(environment).into(),
             ..Configuration::default()
         },
-        symbols::perps::ETH, // symbol
-        None,                // limit
-        None,                // start_time_at_millis
-        None,                // end_time_at_millis
-        None,                // page
+        "ETH-PERP", // symbol
+        None,       // limit
+        None,       // start_time_at_millis
+        None,       // end_time_at_millis
+        None,       // page
     )
     .await?;
 

--- a/rust/examples/exchange-info.rs
+++ b/rust/examples/exchange-info.rs
@@ -7,8 +7,9 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_exchange_info(&Configuration {
-        base_path: exchange::testnet::URL.into(),
+        base_path: exchange::url(environment).into(),
         ..Configuration::default()
     })
     .await?;

--- a/rust/examples/exchange-ticker.rs
+++ b/rust/examples/exchange-ticker.rs
@@ -7,12 +7,13 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_market_ticker(
         &Configuration {
-            base_path: exchange::testnet::URL.into(),
+            base_path: exchange::url(environment).into(),
             ..Configuration::default()
         },
-        symbols::perps::ETH, // symbol
+        "ETH-PERP", // symbol
     )
     .await?;
 

--- a/rust/examples/exchange-tickers.rs
+++ b/rust/examples/exchange-tickers.rs
@@ -7,8 +7,9 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_all_market_ticker(&Configuration {
-        base_path: exchange::testnet::URL.into(),
+        base_path: exchange::url(environment).into(),
         ..Configuration::default()
     })
     .await?;

--- a/rust/examples/exchange-trades.rs
+++ b/rust/examples/exchange-trades.rs
@@ -7,17 +7,18 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let response = get_recent_trades(
         &Configuration {
-            base_path: exchange::testnet::URL.into(),
+            base_path: exchange::url(environment).into(),
             ..Configuration::default()
         },
-        symbols::perps::SUI, // symbol
-        None,                // trade_type
-        Some(5),             // limit
-        None,                // start_time_at_millis
-        None,                // end_time_at_millis
-        None,                // page
+        "ETH-PERP", // symbol
+        None,       // trade_type
+        Some(5),    // limit
+        None,       // start_time_at_millis
+        None,       // end_time_at_millis
+        None,       // page
     )
     .await?;
 

--- a/rust/examples/trade-account-authorization.rs
+++ b/rust/examples/trade-account-authorization.rs
@@ -46,17 +46,17 @@ async fn send_request(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let contracts_info = exchange::info::contracts_config(Environment::Devnet).await?;
+    let environment = Environment::Staging;
+    let contracts_info = exchange::info::contracts_config(environment).await?;
 
-    let environment = Environment::Devnet;
     let time_now = Utc::now().timestamp_millis();
 
     // Authorize account
     let request = AccountAuthorizationRequestExt::new(
         AccountAuthorizationRequest {
             signed_fields: AccountAuthorizationRequestSignedFields {
-                account_address: test::account::devnet::ADDRESS.into(),
-                authorized_account_address: test::account::devnet::ADDRESS.into(),
+                account_address: test::account::address(environment).into(),
+                authorized_account_address: test::account::address(environment).into(),
                 salt: rand::random::<u64>().to_string(),
                 ids_id: contracts_info.ids_id.clone(),
                 signed_at_millis: time_now,
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     );
 
     let request = request.sign(
-        PrivateKey::from_hex(test::account::devnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
         SignatureScheme::Ed25519,
     )?;
 
@@ -78,8 +78,8 @@ async fn main() -> Result<()> {
     let request = AccountAuthorizationRequestExt::new(
         AccountAuthorizationRequest {
             signed_fields: AccountAuthorizationRequestSignedFields {
-                account_address: test::account::devnet::ADDRESS.into(),
-                authorized_account_address: test::account::devnet::ADDRESS.into(),
+                account_address: test::account::address(environment).into(),
+                authorized_account_address: test::account::address(environment).into(),
                 salt: rand::random::<u64>().to_string(),
                 ids_id: contracts_info.ids_id.clone(),
                 signed_at_millis: time_now,
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
     );
 
     let request = request.sign(
-        PrivateKey::from_hex(test::account::devnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
         SignatureScheme::Ed25519,
     )?;
 

--- a/rust/examples/trade-cancel-order.rs
+++ b/rust/examples/trade-cancel-order.rs
@@ -31,12 +31,16 @@ type Result<T> = std::result::Result<T, Error>;
 /// # Errors
 ///
 /// Will return `Err` if the request fails, or cannot be submitted.
-async fn send_request(request: CancelOrdersRequest, auth_token: &str) -> Result<()> {
+async fn send_request(
+    request: CancelOrdersRequest,
+    auth_token: &str,
+    environment: Environment,
+) -> Result<()> {
     println!("Sending request...");
     // Send request and get back order hash
     let mut config = Configuration::new();
     config.bearer_access_token = Some(auth_token.into());
-    config.base_path = trade::testnet::URL.into();
+    config.base_path = trade::url(environment).into();
     cancel_orders(&config, request).await?;
 
     Ok(())
@@ -45,12 +49,13 @@ async fn send_request(request: CancelOrdersRequest, auth_token: &str) -> Result<
 async fn send_create_order_request(
     request: CreateOrderRequest,
     auth_token: &str,
+    environment: Environment,
 ) -> Result<String> {
     println!("Sending request...");
     // Send request and get back order hash
     let mut config = Configuration::new();
     config.bearer_access_token = Some(auth_token.into());
-    config.base_path = trade::testnet::URL.into();
+    config.base_path = trade::url(environment).into();
 
     let order_hash = post_create_order(&config, request).await?.order_hash;
 
@@ -146,22 +151,23 @@ async fn listen_to_account_order_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // Then, we construct an authentication request.
     let request = LoginRequest {
-        account_address: test::account::testnet::ADDRESS.into(),
-        audience: auth::testnet::AUDIENCE.into(),
+        account_address: test::account::address(environment).into(),
+        audience: auth::audience(environment).into(),
         signed_at_millis: Utc::now().timestamp_millis(),
     };
 
     // Next, we generate a signature for our request.
     let signature = request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     // Then, we submit our authentication request to the API for the desired environment.
     let auth_token = request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 
@@ -171,7 +177,7 @@ async fn main() -> Result<()> {
     let mut cancellation_receiver = sender.subscribe();
     listen_to_account_order_updates(
         &auth_token,
-        Environment::Testnet,
+        environment,
         sender,
         Duration::from_secs(10),
         Arc::clone(&shutdown_flag),
@@ -196,13 +202,13 @@ async fn main() -> Result<()> {
     });
 
     // We get the exchange info to fetch the IDS_ID
-    let contracts_info = exchange::info::contracts_config(Environment::Testnet).await?;
+    let contracts_info = exchange::info::contracts_config(environment).await?;
 
     // Let's open an order on the book
     let request = CreateOrderRequest {
         signed_fields: CreateOrderRequestSignedFields {
-            symbol: symbols::perps::ETH.into(),
-            account_address: test::account::testnet::ADDRESS.into(),
+            symbol: "ETH-PERP".to_string(),
+            account_address: test::account::address(environment).into(),
             price_e9: (10_000.e9()).to_string(),
             quantity_e9: (1.e9()).to_string(),
             side: OrderSide::Short,
@@ -225,22 +231,22 @@ async fn main() -> Result<()> {
 
     // Then, we sign our order.
     let request = request.sign(
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
         SignatureScheme::Ed25519,
     )?;
 
-    let order_hash = send_create_order_request(request, &auth_token).await?;
+    let order_hash = send_create_order_request(request, &auth_token, environment).await?;
 
     handle.await.expect("Could not join handle");
 
     // Next, we construct our cancellation request.
     let request = CancelOrdersRequest {
-        symbol: symbols::perps::ETH.into(),
+        symbol: "ETH-PERP".to_string(),
         order_hashes: Some(vec![order_hash.clone()]),
     };
 
     // Now, we submit our cancellation request to Blufin.
-    send_request(request, &auth_token).await?;
+    send_request(request, &auth_token, environment).await?;
 
     // Finally, we print a confirmation message.
     println!("Orders Cancellation submitted successfully.");

--- a/rust/examples/trade-update-leverage.rs
+++ b/rust/examples/trade-update-leverage.rs
@@ -17,12 +17,13 @@ type Result<T> = std::result::Result<T, Error>;
 async fn send_request(
     request: AccountPositionLeverageUpdateRequest,
     auth_token: &str,
+    environment: Environment,
 ) -> Result<()> {
     println!("Sending request...");
     // Send request and get back order hash
     let mut config = Configuration::new();
     config.bearer_access_token = Some(auth_token.into());
-    config.base_path = trade::testnet::URL.into();
+    config.base_path = trade::url(environment).into();
 
     put_leverage_update(&config, request).await?;
 
@@ -31,34 +32,35 @@ async fn send_request(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // First, we construct an authentication request.
     let request = LoginRequest {
-        account_address: test::account::testnet::ADDRESS.into(),
-        audience: auth::testnet::AUDIENCE.into(),
+        account_address: test::account::address(environment).into(),
+        audience: auth::audience(environment).into(),
         signed_at_millis: Utc::now().timestamp_millis(),
     };
 
     // Then, we generate a signature for the request.
     let signature = request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     // Next, we submit our authentication request to the API for the desired environment.
     let auth_token = request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 
     // We get the exchange info to fetch the IDS_ID
-    let contracts_info = exchange::info::contracts_config(Environment::Testnet).await?;
+    let contracts_info = exchange::info::contracts_config(environment).await?;
 
     // Then, we construct the request.
     let signed_request = {
         let unsigned_request = AccountPositionLeverageUpdateRequest {
             signed_fields: AccountPositionLeverageUpdateRequestSignedFields {
-                symbol: symbols::perps::ETH.into(),
-                account_address: test::account::testnet::ADDRESS.into(),
+                symbol: "ETH-PERP".to_string(),
+                account_address: test::account::address(environment).into(),
                 leverage_e9: (10.e9()).to_string(),
                 salt: random::<u64>().to_string(),
                 ids_id: contracts_info.ids_id,
@@ -68,13 +70,13 @@ async fn main() -> Result<()> {
         };
 
         unsigned_request.sign(
-            PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+            PrivateKey::from_hex(test::account::private_key(environment))?,
             SignatureScheme::Ed25519,
         )?
     };
 
     // Now, we send the request.
-    send_request(signed_request, &auth_token).await?;
+    send_request(signed_request, &auth_token, environment).await?;
     println!("Leverage Updated");
 
     Ok(())

--- a/rust/examples/ws-candlestick-stream.rs
+++ b/rust/examples/ws-candlestick-stream.rs
@@ -36,7 +36,7 @@ async fn listen_to_candlestick_updates(
         SubscriptionType::Subscribe,
         vec![MarketSubscriptionStreams::new(
             symbol.into(),
-            vec![MarketDataStreamName::Candlestick1mOracle],
+            vec![MarketDataStreamName::Candlestick1mLast],
         )],
     );
 
@@ -104,13 +104,14 @@ async fn listen_to_candlestick_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     listen_to_candlestick_updates(
-        Environment::Testnet,
-        symbols::perps::ETH,
+        environment,
+        "ETH-PERP",
         sender,
-        Duration::from_secs(5),
+        Duration::from_secs(10),
         Arc::clone(&shutdown_flag),
     )
     .await?;

--- a/rust/examples/ws-mark-price-stream.rs
+++ b/rust/examples/ws-mark-price-stream.rs
@@ -128,11 +128,12 @@ async fn listen_to_mark_price_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     listen_to_mark_price_updates(
-        Environment::Testnet,
-        symbols::perps::ETH,
+        environment,
+        "ETH-PERP",
         sender,
         Duration::from_secs(5),
         Arc::clone(&shutdown_flag),

--- a/rust/examples/ws-market-price-stream.rs
+++ b/rust/examples/ws-market-price-stream.rs
@@ -149,22 +149,23 @@ async fn create_order(signed_request: CreateOrderRequest, auth_token: &str) -> R
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // We construct an authentication request to obtain a token.
     let request = LoginRequest {
-        account_address: test::account::testnet::ADDRESS.into(),
-        audience: auth::testnet::AUDIENCE.into(),
+        account_address: test::account::address(environment).into(),
+        audience: auth::audience(environment).into(),
         signed_at_millis: Utc::now().timestamp_millis(),
     };
 
     // Next, we generate a signature for the request.
     let signature = request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     // Then, we submit our authentication request to the API for the desired environment.
     let auth_token = request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 
@@ -172,8 +173,8 @@ async fn main() -> Result<()> {
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     listen_to_market_price_updates(
-        Environment::Testnet,
-        symbols::perps::ETH,
+        environment,
+        "ETH-PERP",
         sender,
         Duration::from_secs(10),
         Arc::clone(&shutdown_flag),
@@ -193,13 +194,13 @@ async fn main() -> Result<()> {
     });
 
     // We get the exchange info to fetch the IDS_ID
-    let contracts_info = exchange::info::contracts_config(Environment::Testnet).await?;
+    let contracts_info = exchange::info::contracts_config(environment).await?;
 
     // Next, we construct an unsigned request.
     let request = CreateOrderRequest {
         signed_fields: CreateOrderRequestSignedFields {
-            symbol: symbols::perps::ETH.into(),
-            account_address: test::account::testnet::ADDRESS.into(),
+            symbol: "ETH-PERP".into(),
+            account_address: test::account::address(environment).into(),
             price_e9: (10_000.e9()).to_string(),
             quantity_e9: (1.e9()).to_string(),
             side: OrderSide::Short,
@@ -222,7 +223,7 @@ async fn main() -> Result<()> {
 
     // Then, we sign our order.
     let request = request.sign(
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
         SignatureScheme::Ed25519,
     )?;
 

--- a/rust/examples/ws-oracle-price-stream.rs
+++ b/rust/examples/ws-oracle-price-stream.rs
@@ -128,12 +128,13 @@ async fn listen_to_oracle_price_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // Stream websocket messages, with a timeout if no messages received after 5 seconds.
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     listen_to_oracle_price_updates(
-        Environment::Testnet,
-        symbols::perps::BTC,
+        environment,
+        "BTC-PERP",
         sender,
         Duration::from_secs(5),
         Arc::clone(&shutdown_flag),

--- a/rust/examples/ws-orderbook-diff-depth-stream.rs
+++ b/rust/examples/ws-orderbook-diff-depth-stream.rs
@@ -123,22 +123,23 @@ async fn create_order(signed_request: CreateOrderRequest, auth_token: &str) -> R
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // We construct an authentication request to obtain a token.
     let request = LoginRequest {
-        account_address: test::account::testnet::ADDRESS.into(),
-        audience: auth::testnet::AUDIENCE.into(),
+        account_address: test::account::address(environment).into(),
+        audience: auth::audience(environment).into(),
         signed_at_millis: Utc::now().timestamp_millis(),
     };
 
     // Next, we generate a signature for the request.
     let signature = request.signature(
         SignatureScheme::Ed25519,
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
     )?;
 
     // Then, we submit our authentication request to the API for the desired environment.
     let auth_token = request
-        .authenticate(&signature, Environment::Testnet)
+        .authenticate(&signature, environment)
         .await?
         .access_token;
 
@@ -146,8 +147,8 @@ async fn main() -> Result<()> {
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     listen_to_diff_depth_updates(
-        Environment::Testnet,
-        symbols::perps::ETH,
+        environment,
+        "ETH-PERP",
         sender,
         Duration::from_secs(20),
         Arc::clone(&shutdown_flag),
@@ -166,13 +167,13 @@ async fn main() -> Result<()> {
     });
 
     // We get the exchange info to fetch the IDS_ID
-    let contracts_info = exchange::info::contracts_config(Environment::Testnet).await?;
+    let contracts_info = exchange::info::contracts_config(environment).await?;
 
     // Create an order to update the orderbook
     let request = CreateOrderRequest {
         signed_fields: CreateOrderRequestSignedFields {
-            symbol: symbols::perps::ETH.into(),
-            account_address: test::account::testnet::ADDRESS.into(),
+            symbol: "ETH-PERP".into(),
+            account_address: test::account::address(environment).into(),
             price_e9: (10_000.e9()).to_string(),
             quantity_e9: (1.e9()).to_string(),
             side: OrderSide::Short,
@@ -193,7 +194,7 @@ async fn main() -> Result<()> {
 
     // Then, we sign our order.
     let request = request.sign(
-        PrivateKey::from_hex(test::account::testnet::PRIVATE_KEY)?,
+        PrivateKey::from_hex(test::account::private_key(environment))?,
         SignatureScheme::Ed25519,
     )?;
     create_order(request, &auth_token).await?;

--- a/rust/examples/ws-recent-trade-stream.rs
+++ b/rust/examples/ws-recent-trade-stream.rs
@@ -103,12 +103,13 @@ async fn listen_to_recent_trade_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // Then, we connect to the market stream WebSocket to listen for ticker.
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     listen_to_recent_trade_updates(
-        Environment::Testnet,
-        symbols::perps::ETH,
+        environment,
+        "ETH-PERP",
         sender,
         Duration::from_secs(5),
         Arc::clone(&shutdown_flag),

--- a/rust/examples/ws-ticker-all-stream.rs
+++ b/rust/examples/ws-ticker-all-stream.rs
@@ -102,11 +102,12 @@ async fn listen_to_ticker_all_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // Then, we connect to the market stream WebSocket to listen for ticker.
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     listen_to_ticker_all_updates(
-        Environment::Testnet,
+        environment,
         sender,
         Duration::from_secs(5),
         Arc::clone(&shutdown_flag),

--- a/rust/examples/ws-ticker-stream.rs
+++ b/rust/examples/ws-ticker-stream.rs
@@ -103,12 +103,13 @@ async fn listen_to_ticker_updates(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let environment = Environment::Staging;
     // Then, we connect to the market stream WebSocket to listen for ticker.
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<MarketStreamMessage>(100);
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     listen_to_ticker_updates(
-        Environment::Testnet,
-        symbols::perps::ETH,
+        environment,
+        "ETH-PERP",
         sender,
         Duration::from_secs(5),
         Arc::clone(&shutdown_flag),

--- a/rust/src/authenticate.rs
+++ b/rust/src/authenticate.rs
@@ -216,7 +216,7 @@ pub mod tests {
 
         let auth_request = LoginRequest {
             account_address: sui_address,
-            audience: env::auth::testnet::AUDIENCE.into(),
+            audience: env::auth::staging::AUDIENCE.into(),
             signed_at_millis: Utc::now().timestamp_millis(),
         };
 
@@ -238,7 +238,7 @@ pub mod tests {
             const RECOVERY_CODE: u8 = 31;
             // Extract the signature and public key bytes
             if signature_bytes.len() != 99 {
-                // 1 signature type flag byte + 65 signature (1 recovery byte + 64 signature bytes) + 33 public key
+                // 1 signature type flag byte + 65 for the signature (1 recovery byte + 64 signature bytes) + 33 public key
                 return Err("Invalid signature length".into());
             }
             let recovery_bit = signature_bytes[1] - RECOVERY_CODE;
@@ -284,7 +284,7 @@ pub mod tests {
 
         let auth_request = LoginRequest {
             account_address: sui_address,
-            audience: env::auth::testnet::AUDIENCE.into(),
+            audience: env::auth::staging::AUDIENCE.into(),
             signed_at_millis: Utc::now().timestamp_millis(),
         };
 
@@ -293,7 +293,7 @@ pub mod tests {
             .map_err(|error| format!("{error:?}"))?;
 
         auth_request
-            .authenticate(&signature, Environment::Testnet)
+            .authenticate(&signature, Environment::Staging)
             .await
             .map_err(|error| format!("{error:?}"))?;
         Ok(())
@@ -308,7 +308,7 @@ pub mod tests {
 
         let auth_request = LoginRequest {
             account_address: sui_address,
-            audience: env::auth::testnet::AUDIENCE.into(),
+            audience: env::auth::staging::AUDIENCE.into(),
             signed_at_millis: Utc::now().timestamp_millis(),
         };
 
@@ -317,7 +317,7 @@ pub mod tests {
             .map_err(|error| format!("{error:?}"))?;
 
         auth_request
-            .authenticate(&signature, Environment::Testnet)
+            .authenticate(&signature, Environment::Staging)
             .await
             .map_err(|error| format!("{error:?}"))?;
         Ok(())

--- a/rust/src/env.rs
+++ b/rust/src/env.rs
@@ -230,7 +230,7 @@ pub mod exchange {
                 ..Configuration::default()
             })
             .await
-            .map_err(|error| error.to_string())?
+            .map_err(|error| -> Error { error.to_string().into() })?
             .contracts_config
             .ok_or("No Contracts Config found".into())
         }
@@ -246,10 +246,8 @@ pub mod exchange {
                 ..Configuration::default()
             })
             .await
-            .map_err(|error| error.to_string())
-            .map_or(Err("No Markets found".into()), |response| {
-                Ok(response.markets)
-            })
+            .map(|response| response.markets)
+            .map_err(|error| -> Error { error.to_string().into() })
         }
 
         /// Returns a list of all assets.
@@ -263,11 +261,8 @@ pub mod exchange {
                 ..Configuration::default()
             })
             .await
-            .map_err(|error| error.to_string())
-            .map_or(
-                Err("No Assets found".into()),
-                |response| Ok(response.assets),
-            )
+            .map(|response| response.assets)
+            .map_err(|error| -> Error { error.to_string().into() })
         }
     }
 

--- a/rust/src/env.rs
+++ b/rust/src/env.rs
@@ -13,14 +13,16 @@ pub enum Environment {
     Mainnet,
 }
 
-#[deprecated(note = "Will not be updated. Use exchange::info::markets() function instead")]
+#[deprecated(note = "Will not be updated anymore.")]
 pub mod symbols {
+    #[deprecated(note = "Use exchange::info::markets() function instead")]
     pub mod perps {
         pub const ETH: &str = "ETH-PERP";
         pub const BTC: &str = "BTC-PERP";
         pub const SUI: &str = "SUI-PERP";
     }
 
+    #[deprecated(note = "Use exchange::info::assets() function instead")]
     pub mod assets {
         pub const USDC: &str = "USDC";
     }
@@ -212,11 +214,13 @@ pub mod exchange {
     pub mod info {
         use super::*;
         use bluefin_api::apis::configuration::Configuration;
-        use bluefin_api::models::{ContractsConfig, Market};
+        use bluefin_api::models::{AssetConfig, ContractsConfig, Market};
 
         type Error = Box<dyn std::error::Error>;
         type Result<T> = std::result::Result<T, Error>;
 
+        /// Returns the contracts config.
+        ///
         /// # Errors
         ///
         /// Will return [`Err`] if client/server communication fails.
@@ -231,6 +235,11 @@ pub mod exchange {
             .ok_or("No Contracts Config found".into())
         }
 
+        /// Returns a list of all markets.
+        ///
+        /// # Errors
+        ///
+        /// Will return [`Err`] if client/server communication fails.
         pub async fn markets(environment: Environment) -> Result<Vec<Market>> {
             bluefin_api::apis::exchange_api::get_exchange_info(&Configuration {
                 base_path: super::url(environment).to_string(),
@@ -241,6 +250,24 @@ pub mod exchange {
             .map_or(Err("No Markets found".into()), |response| {
                 Ok(response.markets)
             })
+        }
+
+        /// Returns a list of all assets.
+        ///
+        /// # Errors
+        ///
+        /// Will return [`Err`] if client/server communication fails.
+        pub async fn assets(environment: Environment) -> Result<Vec<AssetConfig>> {
+            bluefin_api::apis::exchange_api::get_exchange_info(&Configuration {
+                base_path: super::url(environment).to_string(),
+                ..Configuration::default()
+            })
+            .await
+            .map_err(|error| error.to_string())
+            .map_or(
+                Err("No Assets found".into()),
+                |response| Ok(response.assets),
+            )
         }
     }
 

--- a/rust/src/env.rs
+++ b/rust/src/env.rs
@@ -229,8 +229,7 @@ pub mod exchange {
                 base_path: super::url(environment).to_string(),
                 ..Configuration::default()
             })
-            .await
-            .map_err(|error| -> Error { error.to_string().into() })?
+            .await?
             .contracts_config
             .ok_or("No Contracts Config found".into())
         }
@@ -247,7 +246,7 @@ pub mod exchange {
             })
             .await
             .map(|response| response.markets)
-            .map_err(|error| -> Error { error.to_string().into() })
+            .map_err(Error::from)
         }
 
         /// Returns a list of all assets.
@@ -262,7 +261,7 @@ pub mod exchange {
             })
             .await
             .map(|response| response.assets)
-            .map_err(|error| -> Error { error.to_string().into() })
+            .map_err(Error::from)
         }
     }
 

--- a/rust/src/env.rs
+++ b/rust/src/env.rs
@@ -1,10 +1,19 @@
 #[derive(Clone, Copy)]
 pub enum Environment {
+    Dev,
+    Staging,
+    Production,
+
+    // Deprecated aliases
+    #[deprecated(note = "Use Dev instead")]
     Devnet,
+    #[deprecated(note = "Use Staging instead")]
     Testnet,
+    #[deprecated(note = "Use Production instead")]
     Mainnet,
 }
 
+#[deprecated(note = "Will not be updated. Use exchange::info::markets() function instead")]
 pub mod symbols {
     pub mod perps {
         pub const ETH: &str = "ETH-PERP";
@@ -19,7 +28,40 @@ pub mod symbols {
 
 pub mod test {
     pub mod account {
-        pub mod devnet {
+        use crate::env::Environment;
+
+        pub fn address<'a>(environment: Environment) -> &'a str {
+            match environment {
+                Environment::Dev | Environment::Devnet => dev::ADDRESS,
+                Environment::Staging | Environment::Testnet => staging::ADDRESS,
+                Environment::Production | Environment::Mainnet => {
+                    unimplemented!("test address are not available in production")
+                }
+            }
+        }
+
+        pub fn public_key<'a>(environment: Environment) -> &'a str {
+            match environment {
+                Environment::Dev | Environment::Devnet => dev::PUBLIC_KEY,
+                Environment::Staging | Environment::Testnet => staging::PUBLIC_KEY,
+                Environment::Production | Environment::Mainnet => {
+                    unimplemented!("test public key are not available in production")
+                }
+            }
+        }
+
+        pub fn private_key<'a>(environment: Environment) -> &'a str {
+            match environment {
+                Environment::Dev | Environment::Devnet => dev::PRIVATE_KEY,
+                Environment::Staging | Environment::Testnet => staging::PRIVATE_KEY,
+                Environment::Production | Environment::Mainnet => {
+                    unimplemented!("test private key are not available in production")
+                }
+            }
+        }
+
+        #[deprecated(note = "use address(), public_key(), private_key() instead")]
+        pub mod dev {
             pub const ADDRESS: &str =
                 "0x9b11fafc580f23932f379d99ab6cc4c638e85ba4c252fc909296f3f9e6cea786";
             pub const PUBLIC_KEY: &str =
@@ -27,13 +69,24 @@ pub mod test {
             pub const PRIVATE_KEY: &str =
                 "3427d19dcf5781f0874c36c78aec22c03acda435d69efcbf249e8821793567a1";
         }
-        pub mod testnet {
+
+        #[deprecated(note = "use address(), public_key(), private_key() instead")]
+        pub mod staging {
             pub const ADDRESS: &str =
                 "0x9b11fafc580f23932f379d99ab6cc4c638e85ba4c252fc909296f3f9e6cea786";
             pub const PUBLIC_KEY: &str =
                 "989e35904229360dfbf53a9277db36d401f597c4c0a693acc286bf439269a5cb";
             pub const PRIVATE_KEY: &str =
                 "3427d19dcf5781f0874c36c78aec22c03acda435d69efcbf249e8821793567a1";
+        }
+
+        #[deprecated(note = "Use dev instead")]
+        pub mod devnet {
+            pub use super::dev::*;
+        }
+        #[deprecated(note = "Use staging instead")]
+        pub mod testnet {
+            pub use super::staging::*;
         }
     }
 }
@@ -41,34 +94,47 @@ pub mod test {
 pub mod auth {
     use super::Environment;
 
-    pub mod devnet {
+    pub mod dev {
         pub const AUDIENCE: &str = "api";
         pub const URL: &str = "https://auth.api.sui-dev.bluefin.io";
     }
 
-    pub mod testnet {
+    pub mod staging {
         pub const AUDIENCE: &str = "api";
         pub const URL: &str = "https://auth.api.sui-staging.bluefin.io";
     }
 
-    pub mod mainnet {
+    pub mod production {
         pub const AUDIENCE: &str = "api";
         pub const URL: &str = "https://auth.api.sui-prod.bluefin.io";
     }
 
+    #[deprecated(note = "Use dev instead")]
+    pub mod devnet {
+        pub use super::dev::*;
+    }
+    #[deprecated(note = "Use staging instead")]
+    pub mod testnet {
+        pub use super::staging::*;
+    }
+    #[deprecated(note = "Use production instead")]
+    pub mod mainnet {
+        pub use super::production::*;
+    }
+
     pub fn url<'a>(environment: Environment) -> &'a str {
         match environment {
-            Environment::Devnet => devnet::URL,
-            Environment::Testnet => testnet::URL,
-            Environment::Mainnet => mainnet::URL,
+            Environment::Dev | Environment::Devnet => dev::URL,
+            Environment::Staging | Environment::Testnet => staging::URL,
+            Environment::Production | Environment::Mainnet => production::URL,
         }
     }
 
     pub fn audience<'a>(environment: Environment) -> &'a str {
         match environment {
-            Environment::Devnet => devnet::AUDIENCE,
-            Environment::Testnet => testnet::AUDIENCE,
-            Environment::Mainnet => mainnet::AUDIENCE,
+            Environment::Dev | Environment::Devnet => dev::AUDIENCE,
+            Environment::Staging | Environment::Testnet => staging::AUDIENCE,
+            Environment::Production | Environment::Mainnet => production::AUDIENCE,
         }
     }
 }
@@ -78,26 +144,39 @@ pub mod trade {
 
     pub const AUTH_TOKEN_PREFIX: &str = "Bearer";
 
-    pub mod devnet {
+    pub mod dev {
         pub const URL: &str = "https://trade.api.sui-dev.bluefin.io";
         pub const COLOCATED_URL: &str = "http://api.coloc.sui-dev.int.bluefin.io:9090";
     }
 
-    pub mod testnet {
+    pub mod staging {
         pub const URL: &str = "https://trade.api.sui-staging.bluefin.io";
         pub const COLOCATED_URL: &str = "http://api.coloc.sui-staging.int.bluefin.io:9090";
     }
 
-    pub mod mainnet {
+    pub mod production {
         pub const URL: &str = "https://trade.api.sui-prod.bluefin.io";
         pub const COLOCATED_URL: &str = "http://api.coloc.sui-prod.int.bluefin.io:9090";
     }
 
+    #[deprecated(note = "Use dev instead")]
+    pub mod devnet {
+        pub use super::dev::*;
+    }
+    #[deprecated(note = "Use staging instead")]
+    pub mod testnet {
+        pub use super::staging::*;
+    }
+    #[deprecated(note = "Use production instead")]
+    pub mod mainnet {
+        pub use super::production::*;
+    }
+
     pub fn url<'a>(environment: Environment) -> &'a str {
         match environment {
-            Environment::Devnet => devnet::URL,
-            Environment::Testnet => testnet::URL,
-            Environment::Mainnet => mainnet::URL,
+            Environment::Dev | Environment::Devnet => dev::URL,
+            Environment::Staging | Environment::Testnet => staging::URL,
+            Environment::Production | Environment::Mainnet => production::URL,
         }
     }
 }
@@ -105,22 +184,35 @@ pub mod trade {
 pub mod exchange {
     use super::Environment;
 
-    pub mod devnet {
+    pub mod dev {
         pub const URL: &str = "https://api.sui-dev.bluefin.io";
     }
 
-    pub mod testnet {
+    pub mod staging {
         pub const URL: &str = "https://api.sui-staging.bluefin.io";
     }
 
-    pub mod mainnet {
+    pub mod production {
         pub const URL: &str = "https://api.sui-prod.bluefin.io";
+    }
+
+    #[deprecated(note = "Use dev instead")]
+    pub mod devnet {
+        pub use super::dev::*;
+    }
+    #[deprecated(note = "Use staging instead")]
+    pub mod testnet {
+        pub use super::staging::*;
+    }
+    #[deprecated(note = "Use production instead")]
+    pub mod mainnet {
+        pub use super::production::*;
     }
 
     pub mod info {
         use super::*;
         use bluefin_api::apis::configuration::Configuration;
-        use bluefin_api::models::ContractsConfig;
+        use bluefin_api::models::{ContractsConfig, Market};
 
         type Error = Box<dyn std::error::Error>;
         type Result<T> = std::result::Result<T, Error>;
@@ -130,11 +222,7 @@ pub mod exchange {
         /// Will return [`Err`] if client/server communication fails.
         pub async fn contracts_config(environment: Environment) -> Result<ContractsConfig> {
             bluefin_api::apis::exchange_api::get_exchange_info(&Configuration {
-                base_path: match environment {
-                    Environment::Devnet => devnet::URL.into(),
-                    Environment::Testnet => testnet::URL.into(),
-                    Environment::Mainnet => mainnet::URL.into(),
-                },
+                base_path: super::url(environment).to_string(),
                 ..Configuration::default()
             })
             .await
@@ -142,13 +230,25 @@ pub mod exchange {
             .contracts_config
             .ok_or("No Contracts Config found".into())
         }
+
+        pub async fn markets(environment: Environment) -> Result<Vec<Market>> {
+            bluefin_api::apis::exchange_api::get_exchange_info(&Configuration {
+                base_path: super::url(environment).to_string(),
+                ..Configuration::default()
+            })
+            .await
+            .map_err(|error| error.to_string())
+            .map_or(Err("No Markets found".into()), |response| {
+                Ok(response.markets)
+            })
+        }
     }
 
     pub fn url<'a>(environment: Environment) -> &'a str {
         match environment {
-            Environment::Devnet => devnet::URL,
-            Environment::Testnet => testnet::URL,
-            Environment::Mainnet => mainnet::URL,
+            Environment::Dev | Environment::Devnet => dev::URL,
+            Environment::Staging | Environment::Testnet => staging::URL,
+            Environment::Production | Environment::Mainnet => production::URL,
         }
     }
 }
@@ -157,54 +257,82 @@ pub mod account {
     use super::Environment;
 
     pub const AUTH_TOKEN_PREFIX: &str = "Bearer";
-    pub mod devnet {
+
+    pub mod dev {
         pub const URL: &str = "https://api.sui-dev.bluefin.io";
     }
 
-    pub mod testnet {
+    pub mod staging {
         pub const URL: &str = "https://api.sui-staging.bluefin.io";
     }
 
-    pub mod mainnet {
+    pub mod production {
         pub const URL: &str = "https://api.sui-prod.bluefin.io";
+    }
+
+    #[deprecated(note = "Use dev instead")]
+    pub mod devnet {
+        pub use super::dev::*;
+    }
+    #[deprecated(note = "Use staging instead")]
+    pub mod testnet {
+        pub use super::staging::*;
+    }
+    #[deprecated(note = "Use production instead")]
+    pub mod mainnet {
+        pub use super::production::*;
     }
 
     pub fn url<'a>(environment: Environment) -> &'a str {
         match environment {
-            Environment::Devnet => devnet::URL,
-            Environment::Testnet => testnet::URL,
-            Environment::Mainnet => mainnet::URL,
+            Environment::Dev | Environment::Devnet => dev::URL,
+            Environment::Staging | Environment::Testnet => staging::URL,
+            Environment::Production | Environment::Mainnet => production::URL,
         }
     }
 }
 
 pub mod websocket {
     use super::Environment;
+
     pub mod account {
         use super::Environment;
 
-        pub mod devnet {
+        pub mod dev {
             pub const URL: &str = "wss://stream.api.sui-dev.bluefin.io/ws/account";
             pub const COLOCATED_URL: &str = "ws://api.coloc.sui-dev.int.bluefin.io:9091/ws/account";
         }
 
-        pub mod testnet {
+        pub mod staging {
             pub const URL: &str = "wss://stream.api.sui-staging.bluefin.io/ws/account";
             pub const COLOCATED_URL: &str =
                 "ws://api.coloc.sui-staging.int.bluefin.io:9091/ws/account";
         }
 
-        pub mod mainnet {
+        pub mod production {
             pub const URL: &str = "wss://stream.api.sui-prod.bluefin.io/ws/account";
             pub const COLOCATED_URL: &str =
                 "ws://api.coloc.sui-prod.int.bluefin.io:9091/ws/account";
         }
 
+        #[deprecated(note = "Use dev instead")]
+        pub mod devnet {
+            pub use super::dev::*;
+        }
+        #[deprecated(note = "Use staging instead")]
+        pub mod testnet {
+            pub use super::staging::*;
+        }
+        #[deprecated(note = "Use production instead")]
+        pub mod mainnet {
+            pub use super::production::*;
+        }
+
         pub fn url<'a>(environment: Environment) -> &'a str {
             match environment {
-                Environment::Devnet => devnet::URL,
-                Environment::Testnet => testnet::URL,
-                Environment::Mainnet => mainnet::URL,
+                Environment::Dev | Environment::Devnet => dev::URL,
+                Environment::Staging | Environment::Testnet => staging::URL,
+                Environment::Production | Environment::Mainnet => production::URL,
             }
         }
     }
@@ -212,27 +340,40 @@ pub mod websocket {
     pub mod market {
         use super::Environment;
 
-        pub mod devnet {
+        pub mod dev {
             pub const URL: &str = "wss://stream.api.sui-dev.bluefin.io/ws/market";
             pub const COLOCATED_URL: &str = "ws://api.coloc.sui-dev.int.bluefin.io:9091/ws/market";
         }
 
-        pub mod testnet {
+        pub mod staging {
             pub const URL: &str = "wss://stream.api.sui-staging.bluefin.io/ws/market";
             pub const COLOCATED_URL: &str =
                 "ws://api.coloc.sui-staging.int.bluefin.io:9091/ws/market";
         }
 
-        pub mod mainnet {
+        pub mod production {
             pub const URL: &str = "wss://stream.api.sui-prod.bluefin.io/ws/market";
             pub const COLOCATED_URL: &str = "ws://api.coloc.sui-prod.int.bluefin.io:9091/ws/market";
         }
 
+        #[deprecated(note = "Use dev instead")]
+        pub mod devnet {
+            pub use super::dev::*;
+        }
+        #[deprecated(note = "Use staging instead")]
+        pub mod testnet {
+            pub use super::staging::*;
+        }
+        #[deprecated(note = "Use production instead")]
+        pub mod mainnet {
+            pub use super::production::*;
+        }
+
         pub fn url<'a>(environment: Environment) -> &'a str {
             match environment {
-                Environment::Devnet => devnet::URL,
-                Environment::Testnet => testnet::URL,
-                Environment::Mainnet => mainnet::URL,
+                Environment::Dev | Environment::Devnet => dev::URL,
+                Environment::Staging | Environment::Testnet => staging::URL,
+                Environment::Production | Environment::Mainnet => production::URL,
             }
         }
     }


### PR DESCRIPTION
Rust SDK:
- Deprecates old bad naming for environment enum in favor of consistent naming with python sdk
- Adds utility functions to fetch constants based on environment, instead of using environment constant directly
- Deprecates symbols and assets in favor of fetching market and asset data from EVS to get the list of symbols for perps and assets
- Updates examples with better coding practices 