### PR TITLE
[BFP-2450] Update openapi specs for documentation for rewards

### DIFF
--- a/python/sdk/src/openapi_client/api/rewards_api.py
+++ b/python/sdk/src/openapi_client/api/rewards_api.py
@@ -74,9 +74,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> GetAffiliateIntervalOverview200Response:
-        """Get affiliate earnings overview by interval
+        """/rewards/affiliate/intervalOverview
 
-        Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+        Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 
         :param user_address: The address of the user to get interval overview for (required)
         :type user_address: str
@@ -152,9 +152,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[GetAffiliateIntervalOverview200Response]:
-        """Get affiliate earnings overview by interval
+        """/rewards/affiliate/intervalOverview
 
-        Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+        Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 
         :param user_address: The address of the user to get interval overview for (required)
         :type user_address: str
@@ -230,9 +230,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get affiliate earnings overview by interval
+        """/rewards/affiliate/intervalOverview
 
-        Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+        Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 
         :param user_address: The address of the user to get interval overview for (required)
         :type user_address: str
@@ -381,9 +381,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> GetAffiliateLeaderDashboard200Response:
-        """Get affiliate rankings and earnings
+        """/rewards/affiliate/leaderDashboard
 
-        Returns rankings and earnings for affiliates, sorted by the specified category
+        Returns rankings and earnings for affiliates, sorted by the specified category.
 
         :param sort_by: The category to sort rankings by
         :type sort_by: str
@@ -467,9 +467,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[GetAffiliateLeaderDashboard200Response]:
-        """Get affiliate rankings and earnings
+        """/rewards/affiliate/leaderDashboard
 
-        Returns rankings and earnings for affiliates, sorted by the specified category
+        Returns rankings and earnings for affiliates, sorted by the specified category.
 
         :param sort_by: The category to sort rankings by
         :type sort_by: str
@@ -553,9 +553,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get affiliate rankings and earnings
+        """/rewards/affiliate/leaderDashboard
 
-        Returns rankings and earnings for affiliates, sorted by the specified category
+        Returns rankings and earnings for affiliates, sorted by the specified category.
 
         :param sort_by: The category to sort rankings by
         :type sort_by: str
@@ -716,9 +716,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> AffiliateMetadata:
-        """Get affiliate metadata
+        """/rewards/affiliate
 
-        Returns the affiliate metadata
+        Returns the affiliate metadata.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -786,9 +786,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[AffiliateMetadata]:
-        """Get affiliate metadata
+        """/rewards/affiliate
 
-        Returns the affiliate metadata
+        Returns the affiliate metadata.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -856,9 +856,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get affiliate metadata
+        """/rewards/affiliate
 
-        Returns the affiliate metadata
+        Returns the affiliate metadata.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -993,9 +993,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> GetAffiliateOverview200Response:
-        """Get detailed affiliate earnings overview
+        """/rewards/affiliate/overview
 
-        Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+        Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -1087,9 +1087,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[GetAffiliateOverview200Response]:
-        """Get detailed affiliate earnings overview
+        """/rewards/affiliate/overview
 
-        Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+        Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -1181,9 +1181,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get detailed affiliate earnings overview
+        """/rewards/affiliate/overview
 
-        Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+        Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -1360,9 +1360,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> AffiliateSummary:
-        """Get affiliate performance summary
+        """/rewards/affiliate/summary
 
-        Returns performance summary for an affiliate including total referrals, earnings, and rankings
+        Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -1430,9 +1430,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[AffiliateSummary]:
-        """Get affiliate performance summary
+        """/rewards/affiliate/summary
 
-        Returns performance summary for an affiliate including total referrals, earnings, and rankings
+        Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -1500,9 +1500,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get affiliate performance summary
+        """/rewards/affiliate/summary
 
-        Returns performance summary for an affiliate including total referrals, earnings, and rankings
+        Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 
         :param user_address: Specify wallet address. (required)
         :type user_address: str
@@ -1633,9 +1633,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[UserCampaignRewards]:
-        """Get rewards information for a specific campaign
+        """/rewards/campaign
 
-        Returns the rewards earned by users for a specific campaign
+        Returns the rewards earned by users for a specific campaign.
 
         :param campaign_name: Specify the campaign name (required)
         :type campaign_name: str
@@ -1709,9 +1709,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[UserCampaignRewards]]:
-        """Get rewards information for a specific campaign
+        """/rewards/campaign
 
-        Returns the rewards earned by users for a specific campaign
+        Returns the rewards earned by users for a specific campaign.
 
         :param campaign_name: Specify the campaign name (required)
         :type campaign_name: str
@@ -1785,9 +1785,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get rewards information for a specific campaign
+        """/rewards/campaign
 
-        Returns the rewards earned by users for a specific campaign
+        Returns the rewards earned by users for a specific campaign.
 
         :param campaign_name: Specify the campaign name (required)
         :type campaign_name: str
@@ -1930,9 +1930,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[IntervalRewards]:
-        """Get rewards information for the intervals
+        """/rewards
 
-        Returns the rewards earned by users for the intervals .
+        Returns the rewards earned by users for the intervals.
 
         :param interval_number: Optionally specify interval number.
         :type interval_number: int
@@ -1997,9 +1997,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[IntervalRewards]]:
-        """Get rewards information for the intervals
+        """/rewards
 
-        Returns the rewards earned by users for the intervals .
+        Returns the rewards earned by users for the intervals.
 
         :param interval_number: Optionally specify interval number.
         :type interval_number: int
@@ -2064,9 +2064,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get rewards information for the intervals
+        """/rewards
 
-        Returns the rewards earned by users for the intervals .
+        Returns the rewards earned by users for the intervals.
 
         :param interval_number: Optionally specify interval number.
         :type interval_number: int
@@ -2194,7 +2194,7 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[CampaignMetadata]:
-        """Get rewards metadata for the campaigns
+        """/rewards/metadata/campaign
 
         Returns the metadata for the rewards campaigns.
 
@@ -2265,7 +2265,7 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[CampaignMetadata]]:
-        """Get rewards metadata for the campaigns
+        """/rewards/metadata/campaign
 
         Returns the metadata for the rewards campaigns.
 
@@ -2336,7 +2336,7 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get rewards metadata for the campaigns
+        """/rewards/metadata/campaign
 
         Returns the metadata for the rewards campaigns.
 
@@ -2471,9 +2471,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[EpochConfigs]:
-        """Gets the latest epoch configs for the campaigns
+        """/rewards/metadata/epoch/configs
 
-        Returns the latest epoch configs for the campaigns
+        Returns the latest epoch configs for the campaigns.
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -2534,9 +2534,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[EpochConfigs]]:
-        """Gets the latest epoch configs for the campaigns
+        """/rewards/metadata/epoch/configs
 
-        Returns the latest epoch configs for the campaigns
+        Returns the latest epoch configs for the campaigns.
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -2597,9 +2597,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Gets the latest epoch configs for the campaigns
+        """/rewards/metadata/epoch/configs
 
-        Returns the latest epoch configs for the campaigns
+        Returns the latest epoch configs for the campaigns.
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -2718,9 +2718,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[EpochMetadata]:
-        """Gets the latest or next epoch for campaign.
+        """/rewards/metadata/epoch
 
-        Returns the latest or next epocht epoch for campaign.
+        Returns the latest or next epoch epoch for campaign.
 
         :param campaign_name: Specify the campaign name
         :type campaign_name: str
@@ -2789,9 +2789,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[EpochMetadata]]:
-        """Gets the latest or next epoch for campaign.
+        """/rewards/metadata/epoch
 
-        Returns the latest or next epocht epoch for campaign.
+        Returns the latest or next epoch epoch for campaign.
 
         :param campaign_name: Specify the campaign name
         :type campaign_name: str
@@ -2860,9 +2860,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Gets the latest or next epoch for campaign.
+        """/rewards/metadata/epoch
 
-        Returns the latest or next epocht epoch for campaign.
+        Returns the latest or next epoch epoch for campaign.
 
         :param campaign_name: Specify the campaign name
         :type campaign_name: str
@@ -2996,9 +2996,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[IntervalMetadata]:
-        """Gets the interval metadata for provided parameters
+        """/rewards/metadata/interval
 
-        Returns the interval metadata for provided parameters
+        Returns the interval metadata for provided parameters.
 
         :param interval: Either specify an interval number or the string \"next\" or \"latest\".
         :type interval: int
@@ -3063,9 +3063,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[IntervalMetadata]]:
-        """Gets the interval metadata for provided parameters
+        """/rewards/metadata/interval
 
-        Returns the interval metadata for provided parameters
+        Returns the interval metadata for provided parameters.
 
         :param interval: Either specify an interval number or the string \"next\" or \"latest\".
         :type interval: int
@@ -3130,9 +3130,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Gets the interval metadata for provided parameters
+        """/rewards/metadata/interval
 
-        Returns the interval metadata for provided parameters
+        Returns the interval metadata for provided parameters.
 
         :param interval: Either specify an interval number or the string \"next\" or \"latest\".
         :type interval: int
@@ -3257,7 +3257,7 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[RewardsSummary]:
-        """Get rewards information for all time rewards earned
+        """/rewards/summary
 
         Returns the all time rewards earned by users.
 
@@ -3320,7 +3320,7 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[RewardsSummary]]:
-        """Get rewards information for all time rewards earned
+        """/rewards/summary
 
         Returns the all time rewards earned by users.
 
@@ -3383,7 +3383,7 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get rewards information for all time rewards earned
+        """/rewards/summary
 
         Returns the all time rewards earned by users.
 
@@ -3504,9 +3504,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> AffiliateOnboardResponse:
-        """Submit affiliate onboarding application
+        """/rewards/affiliate/onboard
 
-        Submit an application to become an affiliate
+        Submit an application to become an affiliate.
 
         :param onboard_affiliate_request: (required)
         :type onboard_affiliate_request: OnboardAffiliateRequest
@@ -3574,9 +3574,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[AffiliateOnboardResponse]:
-        """Submit affiliate onboarding application
+        """/rewards/affiliate/onboard
 
-        Submit an application to become an affiliate
+        Submit an application to become an affiliate.
 
         :param onboard_affiliate_request: (required)
         :type onboard_affiliate_request: OnboardAffiliateRequest
@@ -3644,9 +3644,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Submit affiliate onboarding application
+        """/rewards/affiliate/onboard
 
-        Submit an application to become an affiliate
+        Submit an application to become an affiliate.
 
         :param onboard_affiliate_request: (required)
         :type onboard_affiliate_request: OnboardAffiliateRequest
@@ -3787,9 +3787,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RefereeOnboardResponse:
-        """Onboard referee with a referral code
+        """/rewards/affiliate/onboard/referee
 
-        Onboard a referee with a referral code
+        Onboard a referee with a referral code.
 
         :param onboard_referee_request: (required)
         :type onboard_referee_request: OnboardRefereeRequest
@@ -3859,9 +3859,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[RefereeOnboardResponse]:
-        """Onboard referee with a referral code
+        """/rewards/affiliate/onboard/referee
 
-        Onboard a referee with a referral code
+        Onboard a referee with a referral code.
 
         :param onboard_referee_request: (required)
         :type onboard_referee_request: OnboardRefereeRequest
@@ -3931,9 +3931,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Onboard referee with a referral code
+        """/rewards/affiliate/onboard/referee
 
-        Onboard a referee with a referral code
+        Onboard a referee with a referral code.
 
         :param onboard_referee_request: (required)
         :type onboard_referee_request: OnboardRefereeRequest
@@ -4076,9 +4076,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> AffiliateMetadata:
-        """Update affiliate fee config
+        """/rewards/affiliate/feeConfig
 
-        Update the fee config for an affiliate
+        Update the fee config for an affiliate.
 
         :param update_affiliate_fee_config_request: (required)
         :type update_affiliate_fee_config_request: UpdateAffiliateFeeConfigRequest
@@ -4147,9 +4147,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[AffiliateMetadata]:
-        """Update affiliate fee config
+        """/rewards/affiliate/feeConfig
 
-        Update the fee config for an affiliate
+        Update the fee config for an affiliate.
 
         :param update_affiliate_fee_config_request: (required)
         :type update_affiliate_fee_config_request: UpdateAffiliateFeeConfigRequest
@@ -4218,9 +4218,9 @@ class RewardsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Update affiliate fee config
+        """/rewards/affiliate/feeConfig
 
-        Update the fee config for an affiliate
+        Update the fee config for an affiliate.
 
         :param update_affiliate_fee_config_request: (required)
         :type update_affiliate_fee_config_request: UpdateAffiliateFeeConfigRequest

--- a/python/sdk/src/openapi_client/docs/RewardsApi.md
+++ b/python/sdk/src/openapi_client/docs/RewardsApi.md
@@ -4,29 +4,29 @@ All URIs are relative to *https://api.sui-staging.bluefin.io*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**get_affiliate_interval_overview**](RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | Get affiliate earnings overview by interval
-[**get_affiliate_leader_dashboard**](RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | Get affiliate rankings and earnings
-[**get_affiliate_metadata**](RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | Get affiliate metadata
-[**get_affiliate_overview**](RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | Get detailed affiliate earnings overview
-[**get_affiliate_summary**](RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | Get affiliate performance summary
-[**get_campaign_rewards**](RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | Get rewards information for a specific campaign
-[**get_rewards**](RewardsApi.md#get_rewards) | **GET** /v1/rewards | Get rewards information for the intervals
-[**get_rewards_campaign_metadata**](RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | Get rewards metadata for the campaigns
-[**get_rewards_epoch_config_metadata**](RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | Gets the latest epoch configs for the campaigns
-[**get_rewards_epoch_metadata**](RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | Gets the latest or next epoch for campaign.
-[**get_rewards_interval_metadata**](RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | Gets the interval metadata for provided parameters
-[**get_rewards_summary**](RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | Get rewards information for all time rewards earned
-[**onboard_affiliate**](RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | Submit affiliate onboarding application
-[**onboard_referee**](RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | Onboard referee with a referral code
-[**update_affiliate_fee_config**](RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | Update affiliate fee config
+[**get_affiliate_interval_overview**](RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | /rewards/affiliate/intervalOverview
+[**get_affiliate_leader_dashboard**](RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | /rewards/affiliate/leaderDashboard
+[**get_affiliate_metadata**](RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | /rewards/affiliate
+[**get_affiliate_overview**](RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | /rewards/affiliate/overview
+[**get_affiliate_summary**](RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | /rewards/affiliate/summary
+[**get_campaign_rewards**](RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | /rewards/campaign
+[**get_rewards**](RewardsApi.md#get_rewards) | **GET** /v1/rewards | /rewards
+[**get_rewards_campaign_metadata**](RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | /rewards/metadata/campaign
+[**get_rewards_epoch_config_metadata**](RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | /rewards/metadata/epoch/configs
+[**get_rewards_epoch_metadata**](RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | /rewards/metadata/epoch
+[**get_rewards_interval_metadata**](RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | /rewards/metadata/interval
+[**get_rewards_summary**](RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | /rewards/summary
+[**onboard_affiliate**](RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | /rewards/affiliate/onboard
+[**onboard_referee**](RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | /rewards/affiliate/onboard/referee
+[**update_affiliate_fee_config**](RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | /rewards/affiliate/feeConfig
 
 
 # **get_affiliate_interval_overview**
 > GetAffiliateIntervalOverview200Response get_affiliate_interval_overview(user_address, page=page, limit=limit)
 
-Get affiliate earnings overview by interval
+/rewards/affiliate/intervalOverview
 
-Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 
 ### Example
 
@@ -53,7 +53,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     limit = 500 # int | The page size for pagination (optional) (default to 500)
 
     try:
-        # Get affiliate earnings overview by interval
+        # /rewards/affiliate/intervalOverview
         api_response = await api_instance.get_affiliate_interval_overview(user_address, page=page, limit=limit)
         print("The response of RewardsApi->get_affiliate_interval_overview:\n")
         pprint(api_response)
@@ -99,9 +99,9 @@ No authorization required
 # **get_affiliate_leader_dashboard**
 > GetAffiliateLeaderDashboard200Response get_affiliate_leader_dashboard(sort_by=sort_by, sort_order=sort_order, page=page, limit=limit, search=search)
 
-Get affiliate rankings and earnings
+/rewards/affiliate/leaderDashboard
 
-Returns rankings and earnings for affiliates, sorted by the specified category
+Returns rankings and earnings for affiliates, sorted by the specified category.
 
 ### Example
 
@@ -130,7 +130,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     search = 'John' # str | The name/address of the user to filter by (optional)
 
     try:
-        # Get affiliate rankings and earnings
+        # /rewards/affiliate/leaderDashboard
         api_response = await api_instance.get_affiliate_leader_dashboard(sort_by=sort_by, sort_order=sort_order, page=page, limit=limit, search=search)
         print("The response of RewardsApi->get_affiliate_leader_dashboard:\n")
         pprint(api_response)
@@ -178,9 +178,9 @@ No authorization required
 # **get_affiliate_metadata**
 > AffiliateMetadata get_affiliate_metadata(user_address)
 
-Get affiliate metadata
+/rewards/affiliate
 
-Returns the affiliate metadata
+Returns the affiliate metadata.
 
 ### Example
 
@@ -205,7 +205,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     user_address = '0x1234567890abcdef' # str | Specify wallet address.
 
     try:
-        # Get affiliate metadata
+        # /rewards/affiliate
         api_response = await api_instance.get_affiliate_metadata(user_address)
         print("The response of RewardsApi->get_affiliate_metadata:\n")
         pprint(api_response)
@@ -249,9 +249,9 @@ No authorization required
 # **get_affiliate_overview**
 > GetAffiliateOverview200Response get_affiliate_overview(user_address, page=page, limit=limit, sort_by=sort_by, sort_order=sort_order, search=search, min_earnings_e9=min_earnings_e9)
 
-Get detailed affiliate earnings overview
+/rewards/affiliate/overview
 
-Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 
 ### Example
 
@@ -282,7 +282,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     min_earnings_e9 = '0' # str | The minimum earnings to filter by (optional) (default to '0')
 
     try:
-        # Get detailed affiliate earnings overview
+        # /rewards/affiliate/overview
         api_response = await api_instance.get_affiliate_overview(user_address, page=page, limit=limit, sort_by=sort_by, sort_order=sort_order, search=search, min_earnings_e9=min_earnings_e9)
         print("The response of RewardsApi->get_affiliate_overview:\n")
         pprint(api_response)
@@ -332,9 +332,9 @@ No authorization required
 # **get_affiliate_summary**
 > AffiliateSummary get_affiliate_summary(user_address)
 
-Get affiliate performance summary
+/rewards/affiliate/summary
 
-Returns performance summary for an affiliate including total referrals, earnings, and rankings
+Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 
 ### Example
 
@@ -359,7 +359,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     user_address = '0x1234567890abcdef' # str | Specify wallet address.
 
     try:
-        # Get affiliate performance summary
+        # /rewards/affiliate/summary
         api_response = await api_instance.get_affiliate_summary(user_address)
         print("The response of RewardsApi->get_affiliate_summary:\n")
         pprint(api_response)
@@ -403,9 +403,9 @@ No authorization required
 # **get_campaign_rewards**
 > List[UserCampaignRewards] get_campaign_rewards(campaign_name, user_address, epoch_number=epoch_number)
 
-Get rewards information for a specific campaign
+/rewards/campaign
 
-Returns the rewards earned by users for a specific campaign
+Returns the rewards earned by users for a specific campaign.
 
 ### Example
 
@@ -432,7 +432,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     epoch_number = 7 # int | Optionally specify epoch number. (optional)
 
     try:
-        # Get rewards information for a specific campaign
+        # /rewards/campaign
         api_response = await api_instance.get_campaign_rewards(campaign_name, user_address, epoch_number=epoch_number)
         print("The response of RewardsApi->get_campaign_rewards:\n")
         pprint(api_response)
@@ -476,9 +476,9 @@ No authorization required
 # **get_rewards**
 > List[IntervalRewards] get_rewards(interval_number=interval_number)
 
-Get rewards information for the intervals
+/rewards
 
-Returns the rewards earned by users for the intervals .
+Returns the rewards earned by users for the intervals.
 
 ### Example
 
@@ -513,7 +513,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     interval_number = 3 # int | Optionally specify interval number. (optional)
 
     try:
-        # Get rewards information for the intervals
+        # /rewards
         api_response = await api_instance.get_rewards(interval_number=interval_number)
         print("The response of RewardsApi->get_rewards:\n")
         pprint(api_response)
@@ -554,7 +554,7 @@ Name | Type | Description  | Notes
 # **get_rewards_campaign_metadata**
 > List[CampaignMetadata] get_rewards_campaign_metadata(campaign_name=campaign_name, status=status)
 
-Get rewards metadata for the campaigns
+/rewards/metadata/campaign
 
 Returns the metadata for the rewards campaigns.
 
@@ -582,7 +582,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     status = ACTIVE # str | Optionally specify the status of the campaigns. (optional) (default to ACTIVE)
 
     try:
-        # Get rewards metadata for the campaigns
+        # /rewards/metadata/campaign
         api_response = await api_instance.get_rewards_campaign_metadata(campaign_name=campaign_name, status=status)
         print("The response of RewardsApi->get_rewards_campaign_metadata:\n")
         pprint(api_response)
@@ -624,9 +624,9 @@ No authorization required
 # **get_rewards_epoch_config_metadata**
 > List[EpochConfigs] get_rewards_epoch_config_metadata()
 
-Gets the latest epoch configs for the campaigns
+/rewards/metadata/epoch/configs
 
-Returns the latest epoch configs for the campaigns
+Returns the latest epoch configs for the campaigns.
 
 ### Example
 
@@ -650,7 +650,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     api_instance = openapi_client.RewardsApi(api_client)
 
     try:
-        # Gets the latest epoch configs for the campaigns
+        # /rewards/metadata/epoch/configs
         api_response = await api_instance.get_rewards_epoch_config_metadata()
         print("The response of RewardsApi->get_rewards_epoch_config_metadata:\n")
         pprint(api_response)
@@ -688,9 +688,9 @@ No authorization required
 # **get_rewards_epoch_metadata**
 > List[EpochMetadata] get_rewards_epoch_metadata(campaign_name=campaign_name, epoch=epoch)
 
-Gets the latest or next epoch for campaign.
+/rewards/metadata/epoch
 
-Returns the latest or next epocht epoch for campaign.
+Returns the latest or next epoch epoch for campaign.
 
 ### Example
 
@@ -716,7 +716,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     epoch = 'epoch_example' # str | Specify the string \"next\" or \"latest\". (optional)
 
     try:
-        # Gets the latest or next epoch for campaign.
+        # /rewards/metadata/epoch
         api_response = await api_instance.get_rewards_epoch_metadata(campaign_name=campaign_name, epoch=epoch)
         print("The response of RewardsApi->get_rewards_epoch_metadata:\n")
         pprint(api_response)
@@ -758,9 +758,9 @@ No authorization required
 # **get_rewards_interval_metadata**
 > List[IntervalMetadata] get_rewards_interval_metadata(interval=interval)
 
-Gets the interval metadata for provided parameters
+/rewards/metadata/interval
 
-Returns the interval metadata for provided parameters
+Returns the interval metadata for provided parameters.
 
 ### Example
 
@@ -785,7 +785,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     interval = 2 # int | Either specify an interval number or the string \"next\" or \"latest\". (optional)
 
     try:
-        # Gets the interval metadata for provided parameters
+        # /rewards/metadata/interval
         api_response = await api_instance.get_rewards_interval_metadata(interval=interval)
         print("The response of RewardsApi->get_rewards_interval_metadata:\n")
         pprint(api_response)
@@ -826,7 +826,7 @@ No authorization required
 # **get_rewards_summary**
 > List[RewardsSummary] get_rewards_summary()
 
-Get rewards information for all time rewards earned
+/rewards/summary
 
 Returns the all time rewards earned by users.
 
@@ -862,7 +862,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     api_instance = openapi_client.RewardsApi(api_client)
 
     try:
-        # Get rewards information for all time rewards earned
+        # /rewards/summary
         api_response = await api_instance.get_rewards_summary()
         print("The response of RewardsApi->get_rewards_summary:\n")
         pprint(api_response)
@@ -900,9 +900,9 @@ This endpoint does not need any parameter.
 # **onboard_affiliate**
 > AffiliateOnboardResponse onboard_affiliate(onboard_affiliate_request)
 
-Submit affiliate onboarding application
+/rewards/affiliate/onboard
 
-Submit an application to become an affiliate
+Submit an application to become an affiliate.
 
 ### Example
 
@@ -938,7 +938,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     onboard_affiliate_request = openapi_client.OnboardAffiliateRequest() # OnboardAffiliateRequest | 
 
     try:
-        # Submit affiliate onboarding application
+        # /rewards/affiliate/onboard
         api_response = await api_instance.onboard_affiliate(onboard_affiliate_request)
         print("The response of RewardsApi->onboard_affiliate:\n")
         pprint(api_response)
@@ -982,9 +982,9 @@ Name | Type | Description  | Notes
 # **onboard_referee**
 > RefereeOnboardResponse onboard_referee(onboard_referee_request)
 
-Onboard referee with a referral code
+/rewards/affiliate/onboard/referee
 
-Onboard a referee with a referral code
+Onboard a referee with a referral code.
 
 ### Example
 
@@ -1020,7 +1020,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     onboard_referee_request = openapi_client.OnboardRefereeRequest() # OnboardRefereeRequest | 
 
     try:
-        # Onboard referee with a referral code
+        # /rewards/affiliate/onboard/referee
         api_response = await api_instance.onboard_referee(onboard_referee_request)
         print("The response of RewardsApi->onboard_referee:\n")
         pprint(api_response)
@@ -1066,9 +1066,9 @@ Name | Type | Description  | Notes
 # **update_affiliate_fee_config**
 > AffiliateMetadata update_affiliate_fee_config(update_affiliate_fee_config_request)
 
-Update affiliate fee config
+/rewards/affiliate/feeConfig
 
-Update the fee config for an affiliate
+Update the fee config for an affiliate.
 
 ### Example
 
@@ -1104,7 +1104,7 @@ async with openapi_client.ApiClient(configuration) as api_client:
     update_affiliate_fee_config_request = openapi_client.UpdateAffiliateFeeConfigRequest() # UpdateAffiliateFeeConfigRequest | 
 
     try:
-        # Update affiliate fee config
+        # /rewards/affiliate/feeConfig
         api_response = await api_instance.update_affiliate_fee_config(update_affiliate_fee_config_request)
         print("The response of RewardsApi->update_affiliate_fee_config:\n")
         pprint(api_response)

--- a/python/sdk/src/openapi_client_README.md
+++ b/python/sdk/src/openapi_client_README.md
@@ -83,21 +83,21 @@ Class | Method | HTTP request | Description
 *ExchangeApi* | [**get_market_ticker**](openapi_client/docs/ExchangeApi.md#get_market_ticker) | **GET** /v1/exchange/ticker | /exchange/ticker
 *ExchangeApi* | [**get_orderbook_depth**](openapi_client/docs/ExchangeApi.md#get_orderbook_depth) | **GET** /v1/exchange/depth | /exchange/depth
 *ExchangeApi* | [**get_recent_trades**](openapi_client/docs/ExchangeApi.md#get_recent_trades) | **GET** /v1/exchange/trades | /exchange/trades
-*RewardsApi* | [**get_affiliate_interval_overview**](openapi_client/docs/RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | Get affiliate earnings overview by interval
-*RewardsApi* | [**get_affiliate_leader_dashboard**](openapi_client/docs/RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | Get affiliate rankings and earnings
-*RewardsApi* | [**get_affiliate_metadata**](openapi_client/docs/RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | Get affiliate metadata
-*RewardsApi* | [**get_affiliate_overview**](openapi_client/docs/RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | Get detailed affiliate earnings overview
-*RewardsApi* | [**get_affiliate_summary**](openapi_client/docs/RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | Get affiliate performance summary
-*RewardsApi* | [**get_campaign_rewards**](openapi_client/docs/RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | Get rewards information for a specific campaign
-*RewardsApi* | [**get_rewards**](openapi_client/docs/RewardsApi.md#get_rewards) | **GET** /v1/rewards | Get rewards information for the intervals
-*RewardsApi* | [**get_rewards_campaign_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | Get rewards metadata for the campaigns
-*RewardsApi* | [**get_rewards_epoch_config_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | Gets the latest epoch configs for the campaigns
-*RewardsApi* | [**get_rewards_epoch_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | Gets the latest or next epoch for campaign.
-*RewardsApi* | [**get_rewards_interval_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | Gets the interval metadata for provided parameters
-*RewardsApi* | [**get_rewards_summary**](openapi_client/docs/RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | Get rewards information for all time rewards earned
-*RewardsApi* | [**onboard_affiliate**](openapi_client/docs/RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | Submit affiliate onboarding application
-*RewardsApi* | [**onboard_referee**](openapi_client/docs/RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | Onboard referee with a referral code
-*RewardsApi* | [**update_affiliate_fee_config**](openapi_client/docs/RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | Update affiliate fee config
+*RewardsApi* | [**get_affiliate_interval_overview**](openapi_client/docs/RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | /rewards/affiliate/intervalOverview
+*RewardsApi* | [**get_affiliate_leader_dashboard**](openapi_client/docs/RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | /rewards/affiliate/leaderDashboard
+*RewardsApi* | [**get_affiliate_metadata**](openapi_client/docs/RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | /rewards/affiliate
+*RewardsApi* | [**get_affiliate_overview**](openapi_client/docs/RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | /rewards/affiliate/overview
+*RewardsApi* | [**get_affiliate_summary**](openapi_client/docs/RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | /rewards/affiliate/summary
+*RewardsApi* | [**get_campaign_rewards**](openapi_client/docs/RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | /rewards/campaign
+*RewardsApi* | [**get_rewards**](openapi_client/docs/RewardsApi.md#get_rewards) | **GET** /v1/rewards | /rewards
+*RewardsApi* | [**get_rewards_campaign_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | /rewards/metadata/campaign
+*RewardsApi* | [**get_rewards_epoch_config_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | /rewards/metadata/epoch/configs
+*RewardsApi* | [**get_rewards_epoch_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | /rewards/metadata/epoch
+*RewardsApi* | [**get_rewards_interval_metadata**](openapi_client/docs/RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | /rewards/metadata/interval
+*RewardsApi* | [**get_rewards_summary**](openapi_client/docs/RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | /rewards/summary
+*RewardsApi* | [**onboard_affiliate**](openapi_client/docs/RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | /rewards/affiliate/onboard
+*RewardsApi* | [**onboard_referee**](openapi_client/docs/RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | /rewards/affiliate/onboard/referee
+*RewardsApi* | [**update_affiliate_fee_config**](openapi_client/docs/RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | /rewards/affiliate/feeConfig
 *StreamsApi* | [**web_socket_account_data**](openapi_client/docs/StreamsApi.md#web_socket_account_data) | **GET** /ws/account | 
 *StreamsApi* | [**web_socket_market_data**](openapi_client/docs/StreamsApi.md#web_socket_market_data) | **GET** /ws/market | 
 *TradeApi* | [**cancel_orders**](openapi_client/docs/TradeApi.md#cancel_orders) | **PUT** /api/v1/trade/orders/cancel | /trade/orders/cancel

--- a/resources/rewards-data-api.yaml
+++ b/resources/rewards-data-api.yaml
@@ -677,8 +677,8 @@ paths:
       tags:
         - Rewards
       operationId: getRewards
-      summary: Get rewards information for the intervals
-      description: Returns the rewards earned by users for the intervals .
+      summary: /rewards
+      description: Returns the rewards earned by users for the intervals.
       security:
         - bearerAuth: []
       parameters:
@@ -706,8 +706,8 @@ paths:
       tags:
         - Rewards
       operationId: getCampaignRewards
-      summary: Get rewards information for a specific campaign
-      description: Returns the rewards earned by users for a specific campaign
+      summary: /rewards/campaign
+      description: Returns the rewards earned by users for a specific campaign.
       parameters:
         - name: campaignName
           in: query
@@ -751,7 +751,7 @@ paths:
       tags:
         - Rewards
       operationId: getRewardsSummary
-      summary: Get rewards information for all time rewards earned
+      summary: /rewards/summary
       description: Returns the all time rewards earned by users.
       security:
         - bearerAuth: []
@@ -771,7 +771,7 @@ paths:
       tags:
         - Rewards
       operationId: getRewardsCampaignMetadata
-      summary: Get rewards metadata for the campaigns
+      summary: /rewards/metadata/campaign
       description: Returns the metadata for the rewards campaigns.
       parameters:
         - name: campaignName
@@ -807,8 +807,8 @@ paths:
       tags:
         - Rewards
       operationId: getRewardsEpochMetadata
-      summary: Gets the latest or next epoch for campaign.
-      description: Returns the latest or next epocht epoch for campaign.
+      summary: /rewards/metadata/epoch
+      description: Returns the latest or next epoch epoch for campaign.
       parameters:
         - name: campaignName
           in: query
@@ -840,8 +840,8 @@ paths:
       tags:
         - Rewards
       operationId: getRewardsEpochConfigMetadata
-      summary: Gets the latest epoch configs for the campaigns
-      description: Returns the latest epoch configs for the campaigns
+      summary: /rewards/metadata/epoch/configs
+      description: Returns the latest epoch configs for the campaigns.
       responses:
         "200":
           description: Successful response
@@ -858,8 +858,8 @@ paths:
       tags:
         - Rewards
       operationId: getRewardsIntervalMetadata
-      summary: Gets the interval metadata for provided parameters
-      description: Returns the interval metadata for provided parameters
+      summary: /rewards/metadata/interval
+      description: Returns the interval metadata for provided parameters.
       parameters:
         - name: interval
           in: query
@@ -892,8 +892,8 @@ paths:
       tags:
         - Rewards
       operationId: getAffiliateMetadata
-      summary: Get affiliate metadata
-      description: Returns the affiliate metadata
+      summary: /rewards/affiliate
+      description: Returns the affiliate metadata.
       parameters:
         - name: userAddress
           in: query
@@ -933,8 +933,8 @@ paths:
       tags:
         - Rewards
       operationId: onboardAffiliate
-      summary: Submit affiliate onboarding application
-      description: Submit an application to become an affiliate
+      summary: /rewards/affiliate/onboard
+      description: Submit an application to become an affiliate.
       security:
         - bearerAuth: []
       requestBody:
@@ -1012,8 +1012,8 @@ paths:
       tags:
         - Rewards
       operationId: updateAffiliateFeeConfig
-      summary: Update affiliate fee config
-      description: Update the fee config for an affiliate
+      summary: /rewards/affiliate/feeConfig
+      description: Update the fee config for an affiliate.
       security:
         - bearerAuth: []
       requestBody:
@@ -1066,8 +1066,8 @@ paths:
       tags:
         - Rewards
       operationId: onboardReferee
-      summary: Onboard referee with a referral code
-      description: Onboard a referee with a referral code
+      summary: /rewards/affiliate/onboard/referee
+      description: Onboard a referee with a referral code.
       security:
         - bearerAuth: []
       requestBody:
@@ -1126,8 +1126,8 @@ paths:
       tags:
         - Rewards
       operationId: getAffiliateSummary
-      summary: Get affiliate performance summary
-      description: Returns performance summary for an affiliate including total referrals, earnings, and rankings
+      summary: /rewards/affiliate/summary
+      description: Returns performance summary for an affiliate including total referrals, earnings, and rankings.
       parameters:
         - name: userAddress
           in: query
@@ -1167,8 +1167,8 @@ paths:
       tags:
         - Rewards
       operationId: getAffiliateOverview
-      summary: Get detailed affiliate earnings overview
-      description: Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+      summary: /rewards/affiliate/overview
+      description: Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
       parameters:
         - name: page
           in: query
@@ -1281,8 +1281,8 @@ paths:
       tags:
         - Rewards
       operationId: getAffiliateIntervalOverview
-      summary: Get affiliate earnings overview by interval
-      description: Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+      summary: /rewards/affiliate/intervalOverview
+      description: Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
       parameters:
         - name: userAddress
           in: query
@@ -1358,8 +1358,8 @@ paths:
       tags:
         - Rewards
       operationId: getAffiliateLeaderDashboard
-      summary: Get affiliate rankings and earnings
-      description: Returns rankings and earnings for affiliates, sorted by the specified category
+      summary: /rewards/affiliate/leaderDashboard
+      description: Returns rankings and earnings for affiliates, sorted by the specified category.
       parameters:
         - name: sortBy
           in: query

--- a/rust/gen/bluefin_api/README.md
+++ b/rust/gen/bluefin_api/README.md
@@ -43,21 +43,21 @@ Class | Method | HTTP request | Description
 *ExchangeApi* | [**get_market_ticker**](docs/ExchangeApi.md#get_market_ticker) | **GET** /v1/exchange/ticker | /exchange/ticker
 *ExchangeApi* | [**get_orderbook_depth**](docs/ExchangeApi.md#get_orderbook_depth) | **GET** /v1/exchange/depth | /exchange/depth
 *ExchangeApi* | [**get_recent_trades**](docs/ExchangeApi.md#get_recent_trades) | **GET** /v1/exchange/trades | /exchange/trades
-*RewardsApi* | [**get_affiliate_interval_overview**](docs/RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | Get affiliate earnings overview by interval
-*RewardsApi* | [**get_affiliate_leader_dashboard**](docs/RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | Get affiliate rankings and earnings
-*RewardsApi* | [**get_affiliate_metadata**](docs/RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | Get affiliate metadata
-*RewardsApi* | [**get_affiliate_overview**](docs/RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | Get detailed affiliate earnings overview
-*RewardsApi* | [**get_affiliate_summary**](docs/RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | Get affiliate performance summary
-*RewardsApi* | [**get_campaign_rewards**](docs/RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | Get rewards information for a specific campaign
-*RewardsApi* | [**get_rewards**](docs/RewardsApi.md#get_rewards) | **GET** /v1/rewards | Get rewards information for the intervals
-*RewardsApi* | [**get_rewards_campaign_metadata**](docs/RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | Get rewards metadata for the campaigns
-*RewardsApi* | [**get_rewards_epoch_config_metadata**](docs/RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | Gets the latest epoch configs for the campaigns
-*RewardsApi* | [**get_rewards_epoch_metadata**](docs/RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | Gets the latest or next epoch for campaign.
-*RewardsApi* | [**get_rewards_interval_metadata**](docs/RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | Gets the interval metadata for provided parameters
-*RewardsApi* | [**get_rewards_summary**](docs/RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | Get rewards information for all time rewards earned
-*RewardsApi* | [**onboard_affiliate**](docs/RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | Submit affiliate onboarding application
-*RewardsApi* | [**onboard_referee**](docs/RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | Onboard referee with a referral code
-*RewardsApi* | [**update_affiliate_fee_config**](docs/RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | Update affiliate fee config
+*RewardsApi* | [**get_affiliate_interval_overview**](docs/RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | /rewards/affiliate/intervalOverview
+*RewardsApi* | [**get_affiliate_leader_dashboard**](docs/RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | /rewards/affiliate/leaderDashboard
+*RewardsApi* | [**get_affiliate_metadata**](docs/RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | /rewards/affiliate
+*RewardsApi* | [**get_affiliate_overview**](docs/RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | /rewards/affiliate/overview
+*RewardsApi* | [**get_affiliate_summary**](docs/RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | /rewards/affiliate/summary
+*RewardsApi* | [**get_campaign_rewards**](docs/RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | /rewards/campaign
+*RewardsApi* | [**get_rewards**](docs/RewardsApi.md#get_rewards) | **GET** /v1/rewards | /rewards
+*RewardsApi* | [**get_rewards_campaign_metadata**](docs/RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | /rewards/metadata/campaign
+*RewardsApi* | [**get_rewards_epoch_config_metadata**](docs/RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | /rewards/metadata/epoch/configs
+*RewardsApi* | [**get_rewards_epoch_metadata**](docs/RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | /rewards/metadata/epoch
+*RewardsApi* | [**get_rewards_interval_metadata**](docs/RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | /rewards/metadata/interval
+*RewardsApi* | [**get_rewards_summary**](docs/RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | /rewards/summary
+*RewardsApi* | [**onboard_affiliate**](docs/RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | /rewards/affiliate/onboard
+*RewardsApi* | [**onboard_referee**](docs/RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | /rewards/affiliate/onboard/referee
+*RewardsApi* | [**update_affiliate_fee_config**](docs/RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | /rewards/affiliate/feeConfig
 *StreamsApi* | [**web_socket_account_data**](docs/StreamsApi.md#web_socket_account_data) | **GET** /ws/account | 
 *StreamsApi* | [**web_socket_market_data**](docs/StreamsApi.md#web_socket_market_data) | **GET** /ws/market | 
 *TradeApi* | [**cancel_orders**](docs/TradeApi.md#cancel_orders) | **PUT** /api/v1/trade/orders/cancel | /trade/orders/cancel

--- a/rust/gen/bluefin_api/docs/RewardsApi.md
+++ b/rust/gen/bluefin_api/docs/RewardsApi.md
@@ -4,30 +4,30 @@ All URIs are relative to *https://api.sui-staging.bluefin.io*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**get_affiliate_interval_overview**](RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | Get affiliate earnings overview by interval
-[**get_affiliate_leader_dashboard**](RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | Get affiliate rankings and earnings
-[**get_affiliate_metadata**](RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | Get affiliate metadata
-[**get_affiliate_overview**](RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | Get detailed affiliate earnings overview
-[**get_affiliate_summary**](RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | Get affiliate performance summary
-[**get_campaign_rewards**](RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | Get rewards information for a specific campaign
-[**get_rewards**](RewardsApi.md#get_rewards) | **GET** /v1/rewards | Get rewards information for the intervals
-[**get_rewards_campaign_metadata**](RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | Get rewards metadata for the campaigns
-[**get_rewards_epoch_config_metadata**](RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | Gets the latest epoch configs for the campaigns
-[**get_rewards_epoch_metadata**](RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | Gets the latest or next epoch for campaign.
-[**get_rewards_interval_metadata**](RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | Gets the interval metadata for provided parameters
-[**get_rewards_summary**](RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | Get rewards information for all time rewards earned
-[**onboard_affiliate**](RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | Submit affiliate onboarding application
-[**onboard_referee**](RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | Onboard referee with a referral code
-[**update_affiliate_fee_config**](RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | Update affiliate fee config
+[**get_affiliate_interval_overview**](RewardsApi.md#get_affiliate_interval_overview) | **GET** /v1/rewards/affiliate/intervalOverview | /rewards/affiliate/intervalOverview
+[**get_affiliate_leader_dashboard**](RewardsApi.md#get_affiliate_leader_dashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | /rewards/affiliate/leaderDashboard
+[**get_affiliate_metadata**](RewardsApi.md#get_affiliate_metadata) | **GET** /v1/rewards/affiliate | /rewards/affiliate
+[**get_affiliate_overview**](RewardsApi.md#get_affiliate_overview) | **GET** /v1/rewards/affiliate/overview | /rewards/affiliate/overview
+[**get_affiliate_summary**](RewardsApi.md#get_affiliate_summary) | **GET** /v1/rewards/affiliate/summary | /rewards/affiliate/summary
+[**get_campaign_rewards**](RewardsApi.md#get_campaign_rewards) | **GET** /v1/rewards/campaign | /rewards/campaign
+[**get_rewards**](RewardsApi.md#get_rewards) | **GET** /v1/rewards | /rewards
+[**get_rewards_campaign_metadata**](RewardsApi.md#get_rewards_campaign_metadata) | **GET** /v1/rewards/metadata/campaign | /rewards/metadata/campaign
+[**get_rewards_epoch_config_metadata**](RewardsApi.md#get_rewards_epoch_config_metadata) | **GET** /v1/rewards/metadata/epoch/configs | /rewards/metadata/epoch/configs
+[**get_rewards_epoch_metadata**](RewardsApi.md#get_rewards_epoch_metadata) | **GET** /v1/rewards/metadata/epoch | /rewards/metadata/epoch
+[**get_rewards_interval_metadata**](RewardsApi.md#get_rewards_interval_metadata) | **GET** /v1/rewards/metadata/interval | /rewards/metadata/interval
+[**get_rewards_summary**](RewardsApi.md#get_rewards_summary) | **GET** /v1/rewards/summary | /rewards/summary
+[**onboard_affiliate**](RewardsApi.md#onboard_affiliate) | **POST** /v1/rewards/affiliate/onboard | /rewards/affiliate/onboard
+[**onboard_referee**](RewardsApi.md#onboard_referee) | **POST** /v1/rewards/affiliate/onboard/referee | /rewards/affiliate/onboard/referee
+[**update_affiliate_fee_config**](RewardsApi.md#update_affiliate_fee_config) | **POST** /v1/rewards/affiliate/feeConfig | /rewards/affiliate/feeConfig
 
 
 
 ## get_affiliate_interval_overview
 
 > models::GetAffiliateIntervalOverview200Response get_affiliate_interval_overview(user_address, page, limit)
-Get affiliate earnings overview by interval
+/rewards/affiliate/intervalOverview
 
-Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 
 ### Parameters
 
@@ -57,9 +57,9 @@ No authorization required
 ## get_affiliate_leader_dashboard
 
 > models::GetAffiliateLeaderDashboard200Response get_affiliate_leader_dashboard(sort_by, sort_order, page, limit, search)
-Get affiliate rankings and earnings
+/rewards/affiliate/leaderDashboard
 
-Returns rankings and earnings for affiliates, sorted by the specified category
+Returns rankings and earnings for affiliates, sorted by the specified category.
 
 ### Parameters
 
@@ -91,9 +91,9 @@ No authorization required
 ## get_affiliate_metadata
 
 > models::AffiliateMetadata get_affiliate_metadata(user_address)
-Get affiliate metadata
+/rewards/affiliate
 
-Returns the affiliate metadata
+Returns the affiliate metadata.
 
 ### Parameters
 
@@ -121,9 +121,9 @@ No authorization required
 ## get_affiliate_overview
 
 > models::GetAffiliateOverview200Response get_affiliate_overview(user_address, page, limit, sort_by, sort_order, search, min_earnings_e9)
-Get detailed affiliate earnings overview
+/rewards/affiliate/overview
 
-Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 
 ### Parameters
 
@@ -157,9 +157,9 @@ No authorization required
 ## get_affiliate_summary
 
 > models::AffiliateSummary get_affiliate_summary(user_address)
-Get affiliate performance summary
+/rewards/affiliate/summary
 
-Returns performance summary for an affiliate including total referrals, earnings, and rankings
+Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 
 ### Parameters
 
@@ -187,9 +187,9 @@ No authorization required
 ## get_campaign_rewards
 
 > Vec<models::UserCampaignRewards> get_campaign_rewards(campaign_name, user_address, epoch_number)
-Get rewards information for a specific campaign
+/rewards/campaign
 
-Returns the rewards earned by users for a specific campaign
+Returns the rewards earned by users for a specific campaign.
 
 ### Parameters
 
@@ -219,9 +219,9 @@ No authorization required
 ## get_rewards
 
 > Vec<models::IntervalRewards> get_rewards(interval_number)
-Get rewards information for the intervals
+/rewards
 
-Returns the rewards earned by users for the intervals .
+Returns the rewards earned by users for the intervals.
 
 ### Parameters
 
@@ -249,7 +249,7 @@ Name | Type | Description  | Required | Notes
 ## get_rewards_campaign_metadata
 
 > Vec<models::CampaignMetadata> get_rewards_campaign_metadata(campaign_name, status)
-Get rewards metadata for the campaigns
+/rewards/metadata/campaign
 
 Returns the metadata for the rewards campaigns.
 
@@ -280,9 +280,9 @@ No authorization required
 ## get_rewards_epoch_config_metadata
 
 > Vec<models::EpochConfigs> get_rewards_epoch_config_metadata()
-Gets the latest epoch configs for the campaigns
+/rewards/metadata/epoch/configs
 
-Returns the latest epoch configs for the campaigns
+Returns the latest epoch configs for the campaigns.
 
 ### Parameters
 
@@ -307,9 +307,9 @@ No authorization required
 ## get_rewards_epoch_metadata
 
 > Vec<models::EpochMetadata> get_rewards_epoch_metadata(campaign_name, epoch)
-Gets the latest or next epoch for campaign.
+/rewards/metadata/epoch
 
-Returns the latest or next epocht epoch for campaign.
+Returns the latest or next epoch epoch for campaign.
 
 ### Parameters
 
@@ -338,9 +338,9 @@ No authorization required
 ## get_rewards_interval_metadata
 
 > Vec<models::IntervalMetadata> get_rewards_interval_metadata(interval)
-Gets the interval metadata for provided parameters
+/rewards/metadata/interval
 
-Returns the interval metadata for provided parameters
+Returns the interval metadata for provided parameters.
 
 ### Parameters
 
@@ -368,7 +368,7 @@ No authorization required
 ## get_rewards_summary
 
 > Vec<models::RewardsSummary> get_rewards_summary()
-Get rewards information for all time rewards earned
+/rewards/summary
 
 Returns the all time rewards earned by users.
 
@@ -395,9 +395,9 @@ This endpoint does not need any parameter.
 ## onboard_affiliate
 
 > models::AffiliateOnboardResponse onboard_affiliate(onboard_affiliate_request)
-Submit affiliate onboarding application
+/rewards/affiliate/onboard
 
-Submit an application to become an affiliate
+Submit an application to become an affiliate.
 
 ### Parameters
 
@@ -425,9 +425,9 @@ Name | Type | Description  | Required | Notes
 ## onboard_referee
 
 > models::RefereeOnboardResponse onboard_referee(onboard_referee_request)
-Onboard referee with a referral code
+/rewards/affiliate/onboard/referee
 
-Onboard a referee with a referral code
+Onboard a referee with a referral code.
 
 ### Parameters
 
@@ -455,9 +455,9 @@ Name | Type | Description  | Required | Notes
 ## update_affiliate_fee_config
 
 > models::AffiliateMetadata update_affiliate_fee_config(update_affiliate_fee_config_request)
-Update affiliate fee config
+/rewards/affiliate/feeConfig
 
-Update the fee config for an affiliate
+Update the fee config for an affiliate.
 
 ### Parameters
 

--- a/rust/gen/bluefin_api/src/apis/rewards_api.rs
+++ b/rust/gen/bluefin_api/src/apis/rewards_api.rs
@@ -149,7 +149,7 @@ pub enum UpdateAffiliateFeeConfigError {
 }
 
 
-/// Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+/// Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 pub async fn get_affiliate_interval_overview(configuration: &configuration::Configuration, user_address: &str, page: Option<u32>, limit: Option<u32>) -> Result<models::GetAffiliateIntervalOverview200Response, Error<GetAffiliateIntervalOverviewError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_user_address = user_address;
@@ -195,7 +195,7 @@ pub async fn get_affiliate_interval_overview(configuration: &configuration::Conf
     }
 }
 
-/// Returns rankings and earnings for affiliates, sorted by the specified category
+/// Returns rankings and earnings for affiliates, sorted by the specified category.
 pub async fn get_affiliate_leader_dashboard(configuration: &configuration::Configuration, sort_by: Option<&str>, sort_order: Option<&str>, page: Option<u32>, limit: Option<u32>, search: Option<&str>) -> Result<models::GetAffiliateLeaderDashboard200Response, Error<GetAffiliateLeaderDashboardError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_sort_by = sort_by;
@@ -251,7 +251,7 @@ pub async fn get_affiliate_leader_dashboard(configuration: &configuration::Confi
     }
 }
 
-/// Returns the affiliate metadata
+/// Returns the affiliate metadata.
 pub async fn get_affiliate_metadata(configuration: &configuration::Configuration, user_address: &str) -> Result<models::AffiliateMetadata, Error<GetAffiliateMetadataError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_user_address = user_address;
@@ -289,7 +289,7 @@ pub async fn get_affiliate_metadata(configuration: &configuration::Configuration
     }
 }
 
-/// Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+/// Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 pub async fn get_affiliate_overview(configuration: &configuration::Configuration, user_address: &str, page: Option<u32>, limit: Option<u32>, sort_by: Option<&str>, sort_order: Option<&str>, search: Option<&str>, min_earnings_e9: Option<&str>) -> Result<models::GetAffiliateOverview200Response, Error<GetAffiliateOverviewError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_user_address = user_address;
@@ -351,7 +351,7 @@ pub async fn get_affiliate_overview(configuration: &configuration::Configuration
     }
 }
 
-/// Returns performance summary for an affiliate including total referrals, earnings, and rankings
+/// Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 pub async fn get_affiliate_summary(configuration: &configuration::Configuration, user_address: &str) -> Result<models::AffiliateSummary, Error<GetAffiliateSummaryError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_user_address = user_address;
@@ -389,7 +389,7 @@ pub async fn get_affiliate_summary(configuration: &configuration::Configuration,
     }
 }
 
-/// Returns the rewards earned by users for a specific campaign
+/// Returns the rewards earned by users for a specific campaign.
 pub async fn get_campaign_rewards(configuration: &configuration::Configuration, campaign_name: &str, user_address: &str, epoch_number: Option<i32>) -> Result<Vec<models::UserCampaignRewards>, Error<GetCampaignRewardsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_campaign_name = campaign_name;
@@ -433,7 +433,7 @@ pub async fn get_campaign_rewards(configuration: &configuration::Configuration, 
     }
 }
 
-/// Returns the rewards earned by users for the intervals .
+/// Returns the rewards earned by users for the intervals.
 pub async fn get_rewards(configuration: &configuration::Configuration, interval_number: Option<i32>) -> Result<Vec<models::IntervalRewards>, Error<GetRewardsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_interval_number = interval_number;
@@ -520,7 +520,7 @@ pub async fn get_rewards_campaign_metadata(configuration: &configuration::Config
     }
 }
 
-/// Returns the latest epoch configs for the campaigns
+/// Returns the latest epoch configs for the campaigns.
 pub async fn get_rewards_epoch_config_metadata(configuration: &configuration::Configuration, ) -> Result<Vec<models::EpochConfigs>, Error<GetRewardsEpochConfigMetadataError>> {
 
     let uri_str = format!("{}/v1/rewards/metadata/epoch/configs", configuration.base_path);
@@ -555,7 +555,7 @@ pub async fn get_rewards_epoch_config_metadata(configuration: &configuration::Co
     }
 }
 
-/// Returns the latest or next epocht epoch for campaign.
+/// Returns the latest or next epoch epoch for campaign.
 pub async fn get_rewards_epoch_metadata(configuration: &configuration::Configuration, campaign_name: Option<&str>, epoch: Option<&str>) -> Result<Vec<models::EpochMetadata>, Error<GetRewardsEpochMetadataError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_campaign_name = campaign_name;
@@ -599,7 +599,7 @@ pub async fn get_rewards_epoch_metadata(configuration: &configuration::Configura
     }
 }
 
-/// Returns the interval metadata for provided parameters
+/// Returns the interval metadata for provided parameters.
 pub async fn get_rewards_interval_metadata(configuration: &configuration::Configuration, interval: Option<i32>) -> Result<Vec<models::IntervalMetadata>, Error<GetRewardsIntervalMetadataError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_interval = interval;
@@ -677,7 +677,7 @@ pub async fn get_rewards_summary(configuration: &configuration::Configuration, )
     }
 }
 
-/// Submit an application to become an affiliate
+/// Submit an application to become an affiliate.
 pub async fn onboard_affiliate(configuration: &configuration::Configuration, onboard_affiliate_request: models::OnboardAffiliateRequest) -> Result<models::AffiliateOnboardResponse, Error<OnboardAffiliateError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_onboard_affiliate_request = onboard_affiliate_request;
@@ -718,7 +718,7 @@ pub async fn onboard_affiliate(configuration: &configuration::Configuration, onb
     }
 }
 
-/// Onboard a referee with a referral code
+/// Onboard a referee with a referral code.
 pub async fn onboard_referee(configuration: &configuration::Configuration, onboard_referee_request: models::OnboardRefereeRequest) -> Result<models::RefereeOnboardResponse, Error<OnboardRefereeError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_onboard_referee_request = onboard_referee_request;
@@ -759,7 +759,7 @@ pub async fn onboard_referee(configuration: &configuration::Configuration, onboa
     }
 }
 
-/// Update the fee config for an affiliate
+/// Update the fee config for an affiliate.
 pub async fn update_affiliate_fee_config(configuration: &configuration::Configuration, update_affiliate_fee_config_request: models::UpdateAffiliateFeeConfigRequest) -> Result<models::AffiliateMetadata, Error<UpdateAffiliateFeeConfigError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_update_affiliate_fee_config_request = update_affiliate_fee_config_request;

--- a/ts/sdk/src/api.ts
+++ b/ts/sdk/src/api.ts
@@ -6362,8 +6362,8 @@ export type GetRecentTradesTradeTypeEnum = typeof GetRecentTradesTradeTypeEnum[k
 export const RewardsApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
-         * @summary Get affiliate earnings overview by interval
+         * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
+         * @summary /rewards/affiliate/intervalOverview
          * @param {string} userAddress The address of the user to get interval overview for
          * @param {number} [page] The page number to retrieve in a paginated response
          * @param {number} [limit] The page size for pagination
@@ -6409,8 +6409,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns rankings and earnings for affiliates, sorted by the specified category
-         * @summary Get affiliate rankings and earnings
+         * Returns rankings and earnings for affiliates, sorted by the specified category.
+         * @summary /rewards/affiliate/leaderDashboard
          * @param {GetAffiliateLeaderDashboardSortByEnum} [sortBy] The category to sort rankings by
          * @param {GetAffiliateLeaderDashboardSortOrderEnum} [sortOrder] The order to sort rankings by
          * @param {number} [page] The page number to retrieve in a paginated response
@@ -6464,8 +6464,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns the affiliate metadata
-         * @summary Get affiliate metadata
+         * Returns the affiliate metadata.
+         * @summary /rewards/affiliate
          * @param {string} userAddress Specify wallet address.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -6501,8 +6501,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
-         * @summary Get detailed affiliate earnings overview
+         * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
+         * @summary /rewards/affiliate/overview
          * @param {string} userAddress Specify wallet address.
          * @param {number} [page] The page number to retrieve in a paginated response
          * @param {number} [limit] The page size for pagination
@@ -6568,8 +6568,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns performance summary for an affiliate including total referrals, earnings, and rankings
-         * @summary Get affiliate performance summary
+         * Returns performance summary for an affiliate including total referrals, earnings, and rankings.
+         * @summary /rewards/affiliate/summary
          * @param {string} userAddress Specify wallet address.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -6605,8 +6605,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns the rewards earned by users for a specific campaign
-         * @summary Get rewards information for a specific campaign
+         * Returns the rewards earned by users for a specific campaign.
+         * @summary /rewards/campaign
          * @param {string} campaignName Specify the campaign name
          * @param {string} userAddress Specify wallet address.
          * @param {number} [epochNumber] Optionally specify epoch number.
@@ -6654,8 +6654,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns the rewards earned by users for the intervals .
-         * @summary Get rewards information for the intervals
+         * Returns the rewards earned by users for the intervals.
+         * @summary /rewards
          * @param {number} [intervalNumber] Optionally specify interval number.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -6694,7 +6694,7 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * Returns the metadata for the rewards campaigns.
-         * @summary Get rewards metadata for the campaigns
+         * @summary /rewards/metadata/campaign
          * @param {string} [campaignName] Specify the campaign name
          * @param {GetRewardsCampaignMetadataStatusEnum} [status] Optionally specify the status of the campaigns.
          * @param {*} [options] Override http request option.
@@ -6733,8 +6733,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns the latest epoch configs for the campaigns
-         * @summary Gets the latest epoch configs for the campaigns
+         * Returns the latest epoch configs for the campaigns.
+         * @summary /rewards/metadata/epoch/configs
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -6763,8 +6763,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns the latest or next epocht epoch for campaign.
-         * @summary Gets the latest or next epoch for campaign.
+         * Returns the latest or next epoch epoch for campaign.
+         * @summary /rewards/metadata/epoch
          * @param {string} [campaignName] Specify the campaign name
          * @param {GetRewardsEpochMetadataEpochEnum} [epoch] Specify the string \&quot;next\&quot; or \&quot;latest\&quot;.
          * @param {*} [options] Override http request option.
@@ -6803,8 +6803,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Returns the interval metadata for provided parameters
-         * @summary Gets the interval metadata for provided parameters
+         * Returns the interval metadata for provided parameters.
+         * @summary /rewards/metadata/interval
          * @param {number} [interval] Either specify an interval number or the string \&quot;next\&quot; or \&quot;latest\&quot;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -6839,7 +6839,7 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * Returns the all time rewards earned by users.
-         * @summary Get rewards information for all time rewards earned
+         * @summary /rewards/summary
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -6872,8 +6872,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Submit an application to become an affiliate
-         * @summary Submit affiliate onboarding application
+         * Submit an application to become an affiliate.
+         * @summary /rewards/affiliate/onboard
          * @param {OnboardAffiliateRequest} onboardAffiliateRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -6912,8 +6912,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Onboard a referee with a referral code
-         * @summary Onboard referee with a referral code
+         * Onboard a referee with a referral code.
+         * @summary /rewards/affiliate/onboard/referee
          * @param {OnboardRefereeRequest} onboardRefereeRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -6952,8 +6952,8 @@ export const RewardsApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Update the fee config for an affiliate
-         * @summary Update affiliate fee config
+         * Update the fee config for an affiliate.
+         * @summary /rewards/affiliate/feeConfig
          * @param {UpdateAffiliateFeeConfigRequest} updateAffiliateFeeConfigRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7002,8 +7002,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = RewardsApiAxiosParamCreator(configuration)
     return {
         /**
-         * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
-         * @summary Get affiliate earnings overview by interval
+         * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
+         * @summary /rewards/affiliate/intervalOverview
          * @param {string} userAddress The address of the user to get interval overview for
          * @param {number} [page] The page number to retrieve in a paginated response
          * @param {number} [limit] The page size for pagination
@@ -7017,8 +7017,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns rankings and earnings for affiliates, sorted by the specified category
-         * @summary Get affiliate rankings and earnings
+         * Returns rankings and earnings for affiliates, sorted by the specified category.
+         * @summary /rewards/affiliate/leaderDashboard
          * @param {GetAffiliateLeaderDashboardSortByEnum} [sortBy] The category to sort rankings by
          * @param {GetAffiliateLeaderDashboardSortOrderEnum} [sortOrder] The order to sort rankings by
          * @param {number} [page] The page number to retrieve in a paginated response
@@ -7034,8 +7034,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns the affiliate metadata
-         * @summary Get affiliate metadata
+         * Returns the affiliate metadata.
+         * @summary /rewards/affiliate
          * @param {string} userAddress Specify wallet address.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7047,8 +7047,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
-         * @summary Get detailed affiliate earnings overview
+         * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
+         * @summary /rewards/affiliate/overview
          * @param {string} userAddress Specify wallet address.
          * @param {number} [page] The page number to retrieve in a paginated response
          * @param {number} [limit] The page size for pagination
@@ -7066,8 +7066,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns performance summary for an affiliate including total referrals, earnings, and rankings
-         * @summary Get affiliate performance summary
+         * Returns performance summary for an affiliate including total referrals, earnings, and rankings.
+         * @summary /rewards/affiliate/summary
          * @param {string} userAddress Specify wallet address.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7079,8 +7079,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns the rewards earned by users for a specific campaign
-         * @summary Get rewards information for a specific campaign
+         * Returns the rewards earned by users for a specific campaign.
+         * @summary /rewards/campaign
          * @param {string} campaignName Specify the campaign name
          * @param {string} userAddress Specify wallet address.
          * @param {number} [epochNumber] Optionally specify epoch number.
@@ -7094,8 +7094,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns the rewards earned by users for the intervals .
-         * @summary Get rewards information for the intervals
+         * Returns the rewards earned by users for the intervals.
+         * @summary /rewards
          * @param {number} [intervalNumber] Optionally specify interval number.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7108,7 +7108,7 @@ export const RewardsApiFp = function(configuration?: Configuration) {
         },
         /**
          * Returns the metadata for the rewards campaigns.
-         * @summary Get rewards metadata for the campaigns
+         * @summary /rewards/metadata/campaign
          * @param {string} [campaignName] Specify the campaign name
          * @param {GetRewardsCampaignMetadataStatusEnum} [status] Optionally specify the status of the campaigns.
          * @param {*} [options] Override http request option.
@@ -7121,8 +7121,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns the latest epoch configs for the campaigns
-         * @summary Gets the latest epoch configs for the campaigns
+         * Returns the latest epoch configs for the campaigns.
+         * @summary /rewards/metadata/epoch/configs
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -7133,8 +7133,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns the latest or next epocht epoch for campaign.
-         * @summary Gets the latest or next epoch for campaign.
+         * Returns the latest or next epoch epoch for campaign.
+         * @summary /rewards/metadata/epoch
          * @param {string} [campaignName] Specify the campaign name
          * @param {GetRewardsEpochMetadataEpochEnum} [epoch] Specify the string \&quot;next\&quot; or \&quot;latest\&quot;.
          * @param {*} [options] Override http request option.
@@ -7147,8 +7147,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Returns the interval metadata for provided parameters
-         * @summary Gets the interval metadata for provided parameters
+         * Returns the interval metadata for provided parameters.
+         * @summary /rewards/metadata/interval
          * @param {number} [interval] Either specify an interval number or the string \&quot;next\&quot; or \&quot;latest\&quot;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7161,7 +7161,7 @@ export const RewardsApiFp = function(configuration?: Configuration) {
         },
         /**
          * Returns the all time rewards earned by users.
-         * @summary Get rewards information for all time rewards earned
+         * @summary /rewards/summary
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -7172,8 +7172,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Submit an application to become an affiliate
-         * @summary Submit affiliate onboarding application
+         * Submit an application to become an affiliate.
+         * @summary /rewards/affiliate/onboard
          * @param {OnboardAffiliateRequest} onboardAffiliateRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7185,8 +7185,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Onboard a referee with a referral code
-         * @summary Onboard referee with a referral code
+         * Onboard a referee with a referral code.
+         * @summary /rewards/affiliate/onboard/referee
          * @param {OnboardRefereeRequest} onboardRefereeRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7198,8 +7198,8 @@ export const RewardsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Update the fee config for an affiliate
-         * @summary Update affiliate fee config
+         * Update the fee config for an affiliate.
+         * @summary /rewards/affiliate/feeConfig
          * @param {UpdateAffiliateFeeConfigRequest} updateAffiliateFeeConfigRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7221,8 +7221,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
     const localVarFp = RewardsApiFp(configuration)
     return {
         /**
-         * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
-         * @summary Get affiliate earnings overview by interval
+         * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
+         * @summary /rewards/affiliate/intervalOverview
          * @param {string} userAddress The address of the user to get interval overview for
          * @param {number} [page] The page number to retrieve in a paginated response
          * @param {number} [limit] The page size for pagination
@@ -7233,8 +7233,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getAffiliateIntervalOverview(userAddress, page, limit, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns rankings and earnings for affiliates, sorted by the specified category
-         * @summary Get affiliate rankings and earnings
+         * Returns rankings and earnings for affiliates, sorted by the specified category.
+         * @summary /rewards/affiliate/leaderDashboard
          * @param {GetAffiliateLeaderDashboardSortByEnum} [sortBy] The category to sort rankings by
          * @param {GetAffiliateLeaderDashboardSortOrderEnum} [sortOrder] The order to sort rankings by
          * @param {number} [page] The page number to retrieve in a paginated response
@@ -7247,8 +7247,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getAffiliateLeaderDashboard(sortBy, sortOrder, page, limit, search, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns the affiliate metadata
-         * @summary Get affiliate metadata
+         * Returns the affiliate metadata.
+         * @summary /rewards/affiliate
          * @param {string} userAddress Specify wallet address.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7257,8 +7257,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getAffiliateMetadata(userAddress, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
-         * @summary Get detailed affiliate earnings overview
+         * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
+         * @summary /rewards/affiliate/overview
          * @param {string} userAddress Specify wallet address.
          * @param {number} [page] The page number to retrieve in a paginated response
          * @param {number} [limit] The page size for pagination
@@ -7273,8 +7273,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getAffiliateOverview(userAddress, page, limit, sortBy, sortOrder, search, minEarningsE9, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns performance summary for an affiliate including total referrals, earnings, and rankings
-         * @summary Get affiliate performance summary
+         * Returns performance summary for an affiliate including total referrals, earnings, and rankings.
+         * @summary /rewards/affiliate/summary
          * @param {string} userAddress Specify wallet address.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7283,8 +7283,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getAffiliateSummary(userAddress, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns the rewards earned by users for a specific campaign
-         * @summary Get rewards information for a specific campaign
+         * Returns the rewards earned by users for a specific campaign.
+         * @summary /rewards/campaign
          * @param {string} campaignName Specify the campaign name
          * @param {string} userAddress Specify wallet address.
          * @param {number} [epochNumber] Optionally specify epoch number.
@@ -7295,8 +7295,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getCampaignRewards(campaignName, userAddress, epochNumber, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns the rewards earned by users for the intervals .
-         * @summary Get rewards information for the intervals
+         * Returns the rewards earned by users for the intervals.
+         * @summary /rewards
          * @param {number} [intervalNumber] Optionally specify interval number.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7306,7 +7306,7 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * Returns the metadata for the rewards campaigns.
-         * @summary Get rewards metadata for the campaigns
+         * @summary /rewards/metadata/campaign
          * @param {string} [campaignName] Specify the campaign name
          * @param {GetRewardsCampaignMetadataStatusEnum} [status] Optionally specify the status of the campaigns.
          * @param {*} [options] Override http request option.
@@ -7316,8 +7316,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getRewardsCampaignMetadata(campaignName, status, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns the latest epoch configs for the campaigns
-         * @summary Gets the latest epoch configs for the campaigns
+         * Returns the latest epoch configs for the campaigns.
+         * @summary /rewards/metadata/epoch/configs
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -7325,8 +7325,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getRewardsEpochConfigMetadata(options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns the latest or next epocht epoch for campaign.
-         * @summary Gets the latest or next epoch for campaign.
+         * Returns the latest or next epoch epoch for campaign.
+         * @summary /rewards/metadata/epoch
          * @param {string} [campaignName] Specify the campaign name
          * @param {GetRewardsEpochMetadataEpochEnum} [epoch] Specify the string \&quot;next\&quot; or \&quot;latest\&quot;.
          * @param {*} [options] Override http request option.
@@ -7336,8 +7336,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getRewardsEpochMetadata(campaignName, epoch, options).then((request) => request(axios, basePath));
         },
         /**
-         * Returns the interval metadata for provided parameters
-         * @summary Gets the interval metadata for provided parameters
+         * Returns the interval metadata for provided parameters.
+         * @summary /rewards/metadata/interval
          * @param {number} [interval] Either specify an interval number or the string \&quot;next\&quot; or \&quot;latest\&quot;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7347,7 +7347,7 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * Returns the all time rewards earned by users.
-         * @summary Get rewards information for all time rewards earned
+         * @summary /rewards/summary
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -7355,8 +7355,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getRewardsSummary(options).then((request) => request(axios, basePath));
         },
         /**
-         * Submit an application to become an affiliate
-         * @summary Submit affiliate onboarding application
+         * Submit an application to become an affiliate.
+         * @summary /rewards/affiliate/onboard
          * @param {OnboardAffiliateRequest} onboardAffiliateRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7365,8 +7365,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.onboardAffiliate(onboardAffiliateRequest, options).then((request) => request(axios, basePath));
         },
         /**
-         * Onboard a referee with a referral code
-         * @summary Onboard referee with a referral code
+         * Onboard a referee with a referral code.
+         * @summary /rewards/affiliate/onboard/referee
          * @param {OnboardRefereeRequest} onboardRefereeRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7375,8 +7375,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.onboardReferee(onboardRefereeRequest, options).then((request) => request(axios, basePath));
         },
         /**
-         * Update the fee config for an affiliate
-         * @summary Update affiliate fee config
+         * Update the fee config for an affiliate.
+         * @summary /rewards/affiliate/feeConfig
          * @param {UpdateAffiliateFeeConfigRequest} updateAffiliateFeeConfigRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -7395,8 +7395,8 @@ export const RewardsApiFactory = function (configuration?: Configuration, basePa
  */
 export class RewardsApi extends BaseAPI {
     /**
-     * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
-     * @summary Get affiliate earnings overview by interval
+     * Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
+     * @summary /rewards/affiliate/intervalOverview
      * @param {string} userAddress The address of the user to get interval overview for
      * @param {number} [page] The page number to retrieve in a paginated response
      * @param {number} [limit] The page size for pagination
@@ -7409,8 +7409,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns rankings and earnings for affiliates, sorted by the specified category
-     * @summary Get affiliate rankings and earnings
+     * Returns rankings and earnings for affiliates, sorted by the specified category.
+     * @summary /rewards/affiliate/leaderDashboard
      * @param {GetAffiliateLeaderDashboardSortByEnum} [sortBy] The category to sort rankings by
      * @param {GetAffiliateLeaderDashboardSortOrderEnum} [sortOrder] The order to sort rankings by
      * @param {number} [page] The page number to retrieve in a paginated response
@@ -7425,8 +7425,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns the affiliate metadata
-     * @summary Get affiliate metadata
+     * Returns the affiliate metadata.
+     * @summary /rewards/affiliate
      * @param {string} userAddress Specify wallet address.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7437,8 +7437,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
-     * @summary Get detailed affiliate earnings overview
+     * Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
+     * @summary /rewards/affiliate/overview
      * @param {string} userAddress Specify wallet address.
      * @param {number} [page] The page number to retrieve in a paginated response
      * @param {number} [limit] The page size for pagination
@@ -7455,8 +7455,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns performance summary for an affiliate including total referrals, earnings, and rankings
-     * @summary Get affiliate performance summary
+     * Returns performance summary for an affiliate including total referrals, earnings, and rankings.
+     * @summary /rewards/affiliate/summary
      * @param {string} userAddress Specify wallet address.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7467,8 +7467,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns the rewards earned by users for a specific campaign
-     * @summary Get rewards information for a specific campaign
+     * Returns the rewards earned by users for a specific campaign.
+     * @summary /rewards/campaign
      * @param {string} campaignName Specify the campaign name
      * @param {string} userAddress Specify wallet address.
      * @param {number} [epochNumber] Optionally specify epoch number.
@@ -7481,8 +7481,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns the rewards earned by users for the intervals .
-     * @summary Get rewards information for the intervals
+     * Returns the rewards earned by users for the intervals.
+     * @summary /rewards
      * @param {number} [intervalNumber] Optionally specify interval number.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7494,7 +7494,7 @@ export class RewardsApi extends BaseAPI {
 
     /**
      * Returns the metadata for the rewards campaigns.
-     * @summary Get rewards metadata for the campaigns
+     * @summary /rewards/metadata/campaign
      * @param {string} [campaignName] Specify the campaign name
      * @param {GetRewardsCampaignMetadataStatusEnum} [status] Optionally specify the status of the campaigns.
      * @param {*} [options] Override http request option.
@@ -7506,8 +7506,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns the latest epoch configs for the campaigns
-     * @summary Gets the latest epoch configs for the campaigns
+     * Returns the latest epoch configs for the campaigns.
+     * @summary /rewards/metadata/epoch/configs
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof RewardsApi
@@ -7517,8 +7517,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns the latest or next epocht epoch for campaign.
-     * @summary Gets the latest or next epoch for campaign.
+     * Returns the latest or next epoch epoch for campaign.
+     * @summary /rewards/metadata/epoch
      * @param {string} [campaignName] Specify the campaign name
      * @param {GetRewardsEpochMetadataEpochEnum} [epoch] Specify the string \&quot;next\&quot; or \&quot;latest\&quot;.
      * @param {*} [options] Override http request option.
@@ -7530,8 +7530,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Returns the interval metadata for provided parameters
-     * @summary Gets the interval metadata for provided parameters
+     * Returns the interval metadata for provided parameters.
+     * @summary /rewards/metadata/interval
      * @param {number} [interval] Either specify an interval number or the string \&quot;next\&quot; or \&quot;latest\&quot;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7543,7 +7543,7 @@ export class RewardsApi extends BaseAPI {
 
     /**
      * Returns the all time rewards earned by users.
-     * @summary Get rewards information for all time rewards earned
+     * @summary /rewards/summary
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof RewardsApi
@@ -7553,8 +7553,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Submit an application to become an affiliate
-     * @summary Submit affiliate onboarding application
+     * Submit an application to become an affiliate.
+     * @summary /rewards/affiliate/onboard
      * @param {OnboardAffiliateRequest} onboardAffiliateRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7565,8 +7565,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Onboard a referee with a referral code
-     * @summary Onboard referee with a referral code
+     * Onboard a referee with a referral code.
+     * @summary /rewards/affiliate/onboard/referee
      * @param {OnboardRefereeRequest} onboardRefereeRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7577,8 +7577,8 @@ export class RewardsApi extends BaseAPI {
     }
 
     /**
-     * Update the fee config for an affiliate
-     * @summary Update affiliate fee config
+     * Update the fee config for an affiliate.
+     * @summary /rewards/affiliate/feeConfig
      * @param {UpdateAffiliateFeeConfigRequest} updateAffiliateFeeConfigRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}

--- a/ts/sdk/src/docs/RewardsApi.md
+++ b/ts/sdk/src/docs/RewardsApi.md
@@ -4,26 +4,26 @@ All URIs are relative to *https://api.sui-staging.bluefin.io*
 
 |Method | HTTP request | Description|
 |------------- | ------------- | -------------|
-|[**getAffiliateIntervalOverview**](#getaffiliateintervaloverview) | **GET** /v1/rewards/affiliate/intervalOverview | Get affiliate earnings overview by interval|
-|[**getAffiliateLeaderDashboard**](#getaffiliateleaderdashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | Get affiliate rankings and earnings|
-|[**getAffiliateMetadata**](#getaffiliatemetadata) | **GET** /v1/rewards/affiliate | Get affiliate metadata|
-|[**getAffiliateOverview**](#getaffiliateoverview) | **GET** /v1/rewards/affiliate/overview | Get detailed affiliate earnings overview|
-|[**getAffiliateSummary**](#getaffiliatesummary) | **GET** /v1/rewards/affiliate/summary | Get affiliate performance summary|
-|[**getCampaignRewards**](#getcampaignrewards) | **GET** /v1/rewards/campaign | Get rewards information for a specific campaign|
-|[**getRewards**](#getrewards) | **GET** /v1/rewards | Get rewards information for the intervals|
-|[**getRewardsCampaignMetadata**](#getrewardscampaignmetadata) | **GET** /v1/rewards/metadata/campaign | Get rewards metadata for the campaigns|
-|[**getRewardsEpochConfigMetadata**](#getrewardsepochconfigmetadata) | **GET** /v1/rewards/metadata/epoch/configs | Gets the latest epoch configs for the campaigns|
-|[**getRewardsEpochMetadata**](#getrewardsepochmetadata) | **GET** /v1/rewards/metadata/epoch | Gets the latest or next epoch for campaign.|
-|[**getRewardsIntervalMetadata**](#getrewardsintervalmetadata) | **GET** /v1/rewards/metadata/interval | Gets the interval metadata for provided parameters|
-|[**getRewardsSummary**](#getrewardssummary) | **GET** /v1/rewards/summary | Get rewards information for all time rewards earned|
-|[**onboardAffiliate**](#onboardaffiliate) | **POST** /v1/rewards/affiliate/onboard | Submit affiliate onboarding application|
-|[**onboardReferee**](#onboardreferee) | **POST** /v1/rewards/affiliate/onboard/referee | Onboard referee with a referral code|
-|[**updateAffiliateFeeConfig**](#updateaffiliatefeeconfig) | **POST** /v1/rewards/affiliate/feeConfig | Update affiliate fee config|
+|[**getAffiliateIntervalOverview**](#getaffiliateintervaloverview) | **GET** /v1/rewards/affiliate/intervalOverview | /rewards/affiliate/intervalOverview|
+|[**getAffiliateLeaderDashboard**](#getaffiliateleaderdashboard) | **GET** /v1/rewards/affiliate/leaderDashboard | /rewards/affiliate/leaderDashboard|
+|[**getAffiliateMetadata**](#getaffiliatemetadata) | **GET** /v1/rewards/affiliate | /rewards/affiliate|
+|[**getAffiliateOverview**](#getaffiliateoverview) | **GET** /v1/rewards/affiliate/overview | /rewards/affiliate/overview|
+|[**getAffiliateSummary**](#getaffiliatesummary) | **GET** /v1/rewards/affiliate/summary | /rewards/affiliate/summary|
+|[**getCampaignRewards**](#getcampaignrewards) | **GET** /v1/rewards/campaign | /rewards/campaign|
+|[**getRewards**](#getrewards) | **GET** /v1/rewards | /rewards|
+|[**getRewardsCampaignMetadata**](#getrewardscampaignmetadata) | **GET** /v1/rewards/metadata/campaign | /rewards/metadata/campaign|
+|[**getRewardsEpochConfigMetadata**](#getrewardsepochconfigmetadata) | **GET** /v1/rewards/metadata/epoch/configs | /rewards/metadata/epoch/configs|
+|[**getRewardsEpochMetadata**](#getrewardsepochmetadata) | **GET** /v1/rewards/metadata/epoch | /rewards/metadata/epoch|
+|[**getRewardsIntervalMetadata**](#getrewardsintervalmetadata) | **GET** /v1/rewards/metadata/interval | /rewards/metadata/interval|
+|[**getRewardsSummary**](#getrewardssummary) | **GET** /v1/rewards/summary | /rewards/summary|
+|[**onboardAffiliate**](#onboardaffiliate) | **POST** /v1/rewards/affiliate/onboard | /rewards/affiliate/onboard|
+|[**onboardReferee**](#onboardreferee) | **POST** /v1/rewards/affiliate/onboard/referee | /rewards/affiliate/onboard/referee|
+|[**updateAffiliateFeeConfig**](#updateaffiliatefeeconfig) | **POST** /v1/rewards/affiliate/feeConfig | /rewards/affiliate/feeConfig|
 
 # **getAffiliateIntervalOverview**
 > GetAffiliateIntervalOverview200Response getAffiliateIntervalOverview()
 
-Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order
+Returns detailed earnings breakdown for an affiliate by interval, ordered by interval number in descending order.
 
 ### Example
 
@@ -83,7 +83,7 @@ No authorization required
 # **getAffiliateLeaderDashboard**
 > GetAffiliateLeaderDashboard200Response getAffiliateLeaderDashboard()
 
-Returns rankings and earnings for affiliates, sorted by the specified category
+Returns rankings and earnings for affiliates, sorted by the specified category.
 
 ### Example
 
@@ -149,7 +149,7 @@ No authorization required
 # **getAffiliateMetadata**
 > AffiliateMetadata getAffiliateMetadata()
 
-Returns the affiliate metadata
+Returns the affiliate metadata.
 
 ### Example
 
@@ -203,7 +203,7 @@ No authorization required
 # **getAffiliateOverview**
 > GetAffiliateOverview200Response getAffiliateOverview()
 
-Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings
+Returns detailed earnings breakdown for an affiliate users earnings (including perps, spot LP, lending), referral earnings, and total earnings.
 
 ### Example
 
@@ -275,7 +275,7 @@ No authorization required
 # **getAffiliateSummary**
 > AffiliateSummary getAffiliateSummary()
 
-Returns performance summary for an affiliate including total referrals, earnings, and rankings
+Returns performance summary for an affiliate including total referrals, earnings, and rankings.
 
 ### Example
 
@@ -329,7 +329,7 @@ No authorization required
 # **getCampaignRewards**
 > Array<UserCampaignRewards> getCampaignRewards()
 
-Returns the rewards earned by users for a specific campaign
+Returns the rewards earned by users for a specific campaign.
 
 ### Example
 
@@ -387,7 +387,7 @@ No authorization required
 # **getRewards**
 > Array<IntervalRewards> getRewards()
 
-Returns the rewards earned by users for the intervals .
+Returns the rewards earned by users for the intervals.
 
 ### Example
 
@@ -492,7 +492,7 @@ No authorization required
 # **getRewardsEpochConfigMetadata**
 > Array<EpochConfigs> getRewardsEpochConfigMetadata()
 
-Returns the latest epoch configs for the campaigns
+Returns the latest epoch configs for the campaigns.
 
 ### Example
 
@@ -536,7 +536,7 @@ No authorization required
 # **getRewardsEpochMetadata**
 > Array<EpochMetadata> getRewardsEpochMetadata()
 
-Returns the latest or next epocht epoch for campaign.
+Returns the latest or next epoch epoch for campaign.
 
 ### Example
 
@@ -590,7 +590,7 @@ No authorization required
 # **getRewardsIntervalMetadata**
 > Array<IntervalMetadata> getRewardsIntervalMetadata()
 
-Returns the interval metadata for provided parameters
+Returns the interval metadata for provided parameters.
 
 ### Example
 
@@ -685,7 +685,7 @@ This endpoint does not have any parameters.
 # **onboardAffiliate**
 > AffiliateOnboardResponse onboardAffiliate(onboardAffiliateRequest)
 
-Submit an application to become an affiliate
+Submit an application to become an affiliate.
 
 ### Example
 
@@ -740,7 +740,7 @@ const { status, data } = await apiInstance.onboardAffiliate(
 # **onboardReferee**
 > RefereeOnboardResponse onboardReferee(onboardRefereeRequest)
 
-Onboard a referee with a referral code
+Onboard a referee with a referral code.
 
 ### Example
 
@@ -797,7 +797,7 @@ const { status, data } = await apiInstance.onboardReferee(
 # **updateAffiliateFeeConfig**
 > AffiliateMetadata updateAffiliateFeeConfig(updateAffiliateFeeConfigRequest)
 
-Update the fee config for an affiliate
+Update the fee config for an affiliate.
 
 ### Example
 


### PR DESCRIPTION
* Update summary so the doc would pick up the endpoint path as the title
* Update description so the doc would populate the same field