### PR TITLE
fix(BFP-2671): improve access token persistence

### DIFF
--- a/ts/sdk/package.json
+++ b/ts/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/pro-sdk",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "OpenAPI client for @bluefin-exchange/pro-sdk",
   "author": "Bluefin",
   "repository": {


### PR DESCRIPTION
- Fix token refresh cycle timing by basing it on access token liftetime (trigger refresh at 80% of token lifetime) rather than arbitrary interval
- Handle page visibility, network offline/online status tracking to keep token refreshed
- Add appropriate refresh retry logic, don't log user out unnecessarily if the refresh token is still valid