### PR TITLE
update description of expiresAtMillis on orders in public API

### DIFF
--- a/python/sdk/src/openapi_client/docs/CreateOrderRequestSignedFields.md
+++ b/python/sdk/src/openapi_client/docs/CreateOrderRequestSignedFields.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **is_isolated** | **bool** | Is this order isolated or cross margin. Note market must be set to the same mode. | [default to False]
 **salt** | **str** | The random generated SALT. Should always be a number | 
 **ids_id** | **str** | the ID of the internal datastore for the target network | 
-**expires_at_millis** | **int** | timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided | 
+**expires_at_millis** | **int** | The timestamp in millis at which order will expire. | 
 **signed_at_millis** | **int** | The timestamp in millis at which the request was signed | 
 
 ## Example

--- a/python/sdk/src/openapi_client/models/create_order_request_signed_fields.py
+++ b/python/sdk/src/openapi_client/models/create_order_request_signed_fields.py
@@ -36,7 +36,7 @@ class CreateOrderRequestSignedFields(BaseModel):
     is_isolated: StrictBool = Field(description="Is this order isolated or cross margin. Note market must be set to the same mode.", alias="isIsolated")
     salt: StrictStr = Field(description="The random generated SALT. Should always be a number")
     ids_id: StrictStr = Field(description="the ID of the internal datastore for the target network", alias="idsId")
-    expires_at_millis: StrictInt = Field(description="timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided", alias="expiresAtMillis")
+    expires_at_millis: StrictInt = Field(description="The timestamp in millis at which order will expire.", alias="expiresAtMillis")
     signed_at_millis: StrictInt = Field(description="The timestamp in millis at which the request was signed", alias="signedAtMillis")
     __properties: ClassVar[List[str]] = ["symbol", "accountAddress", "priceE9", "quantityE9", "side", "leverageE9", "isIsolated", "salt", "idsId", "expiresAtMillis", "signedAtMillis"]
 

--- a/resources/trade-api.yaml
+++ b/resources/trade-api.yaml
@@ -104,7 +104,7 @@ components:
         expiresAtMillis:
           type: integer
           format: int64
-          description: timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided
+          description: The timestamp in millis at which order will expire.
           example: 12345665432
         signedAtMillis:
           type: integer

--- a/rust/gen/bluefin_api/docs/CreateOrderRequestSignedFields.md
+++ b/rust/gen/bluefin_api/docs/CreateOrderRequestSignedFields.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **is_isolated** | **bool** | Is this order isolated or cross margin. Note market must be set to the same mode. | [default to false]
 **salt** | **String** | The random generated SALT. Should always be a number | 
 **ids_id** | **String** | the ID of the internal datastore for the target network | 
-**expires_at_millis** | **i64** | timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided | 
+**expires_at_millis** | **i64** | The timestamp in millis at which order will expire. | 
 **signed_at_millis** | **i64** | The timestamp in millis at which the request was signed | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/gen/bluefin_api/src/models/create_order_request_signed_fields.rs
+++ b/rust/gen/bluefin_api/src/models/create_order_request_signed_fields.rs
@@ -39,7 +39,7 @@ pub struct CreateOrderRequestSignedFields {
     /// the ID of the internal datastore for the target network
     #[serde(rename = "idsId")]
     pub ids_id: String,
-    /// timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided
+    /// The timestamp in millis at which order will expire.
     #[serde(rename = "expiresAtMillis")]
     pub expires_at_millis: i64,
     /// The timestamp in millis at which the request was signed

--- a/ts/sdk/src/api.ts
+++ b/ts/sdk/src/api.ts
@@ -2047,7 +2047,7 @@ export interface CreateOrderRequestSignedFields {
      */
     'idsId': string;
     /**
-     * timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided
+     * The timestamp in millis at which order will expire.
      * @type {number}
      * @memberof CreateOrderRequestSignedFields
      */

--- a/ts/sdk/src/docs/CreateOrderRequestSignedFields.md
+++ b/ts/sdk/src/docs/CreateOrderRequestSignedFields.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **isIsolated** | **boolean** | Is this order isolated or cross margin. Note market must be set to the same mode. | [default to false]
 **salt** | **string** | The random generated SALT. Should always be a number | [default to undefined]
 **idsId** | **string** | the ID of the internal datastore for the target network | [default to undefined]
-**expiresAtMillis** | **number** | timestamp in millis at which order will expire. Defaults to 1 month for LIMIT orders if not provided | [default to undefined]
+**expiresAtMillis** | **number** | The timestamp in millis at which order will expire. | [default to undefined]
 **signedAtMillis** | **number** | The timestamp in millis at which the request was signed | [default to undefined]
 
 ## Example


### PR DESCRIPTION
### **User description**
Updates the description of expiresAtMillis field in order creation in public API.

Removes erroneous 1 month default on limit orders.


___

### **PR Type**
Documentation


___

### **Description**
- Remove incorrect default expiration information for limit orders

- Update `expiresAtMillis` field descriptions across API documentation

- Standardize field description formatting and capitalization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Schema"] --> B["Generated SDKs"]
  B --> C["TypeScript SDK"]
  B --> D["Python SDK"]
  B --> E["Rust SDK"]
  F["Documentation Files"] --> G["Updated Descriptions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Update TypeScript API field description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ts/sdk/src/api.ts

<ul><li>Remove mention of "1 month default for LIMIT orders"<br> <li> Capitalize and standardize <code>expiresAtMillis</code> field description</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-c8372d5ed2306ce6a30abfa8c4cff8d92ff874216c8773d3d3b4801e908730e1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_order_request_signed_fields.rs</strong><dd><code>Update Rust model field description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/gen/bluefin_api/src/models/create_order_request_signed_fields.rs

<ul><li>Remove incorrect default expiration information<br> <li> Standardize field description formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-6c3ab2ac336a6036581c18af3497cdf2d69a6be8d742b1c3b1a012f3c240eedc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_order_request_signed_fields.py</strong><dd><code>Update Python model field description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/sdk/src/openapi_client/models/create_order_request_signed_fields.py

<ul><li>Remove erroneous "1 month default" text<br> <li> Capitalize field description for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-8cca3b117796f97c13a7962227dca62b97cb1d15704a87c9c835daccbc708923">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateOrderRequestSignedFields.md</strong><dd><code>Update Python SDK documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/sdk/src/openapi_client/docs/CreateOrderRequestSignedFields.md

<ul><li>Update documentation table entry for <code>expires_at_millis</code><br> <li> Remove incorrect default behavior description</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-013f12556e60a8005ff10c5ee9c3ff49c9faccccb5e3b05249398ae05360e053">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trade-api.yaml</strong><dd><code>Update OpenAPI schema definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/trade-api.yaml

<ul><li>Update OpenAPI schema description for <code>expiresAtMillis</code><br> <li> Remove misleading default value information</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-9773f3370b4a1906d139ad90aaf7e2eb0fe7176642d682a6f8455957e6ecff7e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateOrderRequestSignedFields.md</strong><dd><code>Update Rust SDK documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/gen/bluefin_api/docs/CreateOrderRequestSignedFields.md

<ul><li>Update Rust SDK documentation table<br> <li> Remove incorrect default expiration text</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-f562342fe70228ab1cd5937b00fe0585e09d790c9f4336a70fe4a6e035867268">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateOrderRequestSignedFields.md</strong><dd><code>Update TypeScript SDK documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ts/sdk/src/docs/CreateOrderRequestSignedFields.md

<ul><li>Update TypeScript SDK documentation table<br> <li> Remove erroneous default behavior description</ul>


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/pro-sdk/pull/187/files#diff-478c8b2f1215a83cd44cd8cc7f526f2af36b7999c151e60fc6d406d8701e3e73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

